### PR TITLE
Add `AudioCache` for global audio encoding/cache management and integ…

### DIFF
--- a/example.php
+++ b/example.php
@@ -108,6 +108,7 @@ include 'plugins/autoloader.php';
         });
 
 
+        $phone->defineAudioFile('music.wav');
         // ====================================================================
         // SESSÃO 6: CONFIGURAÇÃO DE CODEC E RECURSOS DE ÁUDIO
         // ====================================================================
@@ -120,7 +121,7 @@ include 'plugins/autoloader.php';
         $phone->enableAudioMemorySharing();
 
 
-        $phone->defineAudioFile('silence_5m.wav');
+
         $phone->onAnswer(function (trunkController $phone) {
             cli::pcl("Chamada recebida", "green");
 
@@ -145,9 +146,14 @@ include 'plugins/autoloader.php';
 
 
             $phone->waitSilence(false, 10);
+            interruptibleSleep(5, $phone->receiveBye);
+
 
             $buffer = $phone->getBuffer();
             $bufferLen = $buffer->length();
+
+
+
             if ($bufferLen > 0) {
 
                 cli::pcl("Buffer possui packets: " . $bufferLen, "bold_green");
@@ -190,7 +196,7 @@ include 'plugins/autoloader.php';
         });
 
 
-        $phone->call('553140040104');
+        $phone->call('5569984477329');
 
 
 

--- a/plugins/Utils/audio/AudioCache.php
+++ b/plugins/Utils/audio/AudioCache.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace libspech\Audio;
+
+use libspech\Cache\cache;
+
+/**
+ * Cache global/process-level para áudio pré-codificado por codec.
+ *
+ * Encapsula libspech\Cache\cache para evitar espalhar cache::get/define/unset
+ * por todo o trunkController.
+ *
+ * Chaves internas:
+ *  - libspechAudioEncodedCache    : payload encoded por chave
+ *  - libspechAudioEncodedBuilding : marcação anti-stampede por chave
+ */
+class AudioCache
+{
+    private const KEY_ENCODED  = 'libspechAudioEncodedCache';
+    private const KEY_BUILDING = 'libspechAudioEncodedBuilding';
+
+    private const BUILDING_TIMEOUT = 30; // segundos
+    private const CLEANUP_PROB     = 50; // 1 em N inserções
+
+    public static function makeEncodedKey(
+        string $audioFile,
+        string $codec,
+        int $frequency,
+        int $channels,
+        int $chunkSize,
+        ?int $infoRate = null,
+        ?int $infoChannels = null,
+        ?int $bitDepth = null,
+        $config = null
+    ): string {
+        $realPath = realpath($audioFile) ?: $audioFile;
+        $mtime    = file_exists($audioFile) ? filemtime($audioFile) : 0;
+
+        return md5(json_encode([
+            'file'         => $realPath,
+            'mtime'        => $mtime,
+            'codec'        => strtoupper($codec),
+            'frequency'    => $frequency,
+            'channels'     => $channels,
+            'chunkSize'    => $chunkSize,
+            'infoRate'     => $infoRate,
+            'infoChannels' => $infoChannels,
+            'bitDepth'     => $bitDepth,
+            'config'       => $config,
+        ]));
+    }
+
+    public static function getEncoded(string $key): ?array
+    {
+        $bucket = cache::global()[self::KEY_ENCODED] ?? null;
+        if (is_array($bucket) && isset($bucket[$key]) && is_array($bucket[$key])) {
+            return $bucket[$key];
+        }
+        return null;
+    }
+
+    public static function setEncoded(string $key, array $payload): void
+    {
+        $now = time();
+        $payload['createdAt'] = $payload['createdAt'] ?? $now;
+        $payload['lastUsed']  = $now;
+
+        cache::subDefine(self::KEY_ENCODED, $key, $payload);
+
+        try {
+            if (random_int(1, self::CLEANUP_PROB) === 1) {
+                self::cleanup();
+            }
+        } catch (\Throwable $e) {
+            // cleanup nunca pode quebrar a chamada
+        }
+    }
+
+    public static function hasEncoded(string $key): bool
+    {
+        $bucket = cache::global()[self::KEY_ENCODED] ?? null;
+        return is_array($bucket) && isset($bucket[$key]);
+    }
+
+    public static function markBuilding(string $key): bool
+    {
+        if (self::isBuilding($key)) {
+            return false;
+        }
+        cache::subDefine(self::KEY_BUILDING, $key, time());
+        return true;
+    }
+
+    public static function unmarkBuilding(string $key): void
+    {
+        try {
+            cache::unset(self::KEY_BUILDING, $key);
+        } catch (\Throwable $e) {
+            // noop
+        }
+    }
+
+    public static function isBuilding(string $key): bool
+    {
+        $bucket = cache::global()[self::KEY_BUILDING] ?? null;
+        if (!is_array($bucket) || !isset($bucket[$key])) {
+            return false;
+        }
+        $started = (int) $bucket[$key];
+        if ($started <= 0 || (time() - $started) > self::BUILDING_TIMEOUT) {
+            self::unmarkBuilding($key);
+            return false;
+        }
+        return true;
+    }
+
+    public static function touchEncoded(string $key): void
+    {
+        $bucket = cache::global()[self::KEY_ENCODED] ?? null;
+        if (is_array($bucket) && isset($bucket[$key]) && is_array($bucket[$key])) {
+            $bucket[$key]['lastUsed'] = time();
+            cache::subDefine(self::KEY_ENCODED, $key, $bucket[$key]);
+        }
+    }
+
+    public static function cleanup(int $maxItems = 32, int $ttlSeconds = 3600): void
+    {
+        $bucket = cache::global()[self::KEY_ENCODED] ?? null;
+        if (!is_array($bucket) || empty($bucket)) {
+            return;
+        }
+
+        $now     = time();
+        $changed = false;
+
+        // 1) TTL
+        foreach ($bucket as $k => $item) {
+            $lastUsed = $item['lastUsed'] ?? 0;
+            if (($now - $lastUsed) >= $ttlSeconds && !self::isBuilding($k)) {
+                unset($bucket[$k]);
+                $changed = true;
+            }
+        }
+
+        // 2) Limite de itens (LRU por lastUsed)
+        if (count($bucket) > $maxItems) {
+            uasort($bucket, fn($a, $b) => ($a['lastUsed'] ?? 0) <=> ($b['lastUsed'] ?? 0));
+            foreach ($bucket as $k => $_) {
+                if (count($bucket) <= $maxItems) {
+                    break;
+                }
+                if (!self::isBuilding($k)) {
+                    unset($bucket[$k]);
+                    $changed = true;
+                }
+            }
+        }
+
+        if ($changed) {
+            cache::define(self::KEY_ENCODED, $bucket);
+        }
+    }
+}

--- a/plugins/Utils/libspech/trunkController.php
+++ b/plugins/Utils/libspech/trunkController.php
@@ -3100,6 +3100,54 @@ class trunkController
 
     public bool $audioMemorySharingEnabled = false;
 
+    /**
+     * Modo de resample para reprodução de áudio (defineAudioFile).
+     *  - 'resampler' (padrão): usa resampler() — rápido, menor latência/CPU.
+     *  - 'resample' : usa resample() — alta qualidade (kaiser_best, q=10), mais CPU.
+     */
+    public string $resampleMode = 'resampler';
+
+    /**
+     * Define qual modo de resample será usado no fluxo de áudio.
+     * Valores aceitos: 'resampler' (default) ou 'resample'.
+     */
+    public function setResampleMode(string $mode): void
+    {
+        $mode = strtolower($mode);
+        if (!in_array($mode, ['resampler', 'resample'], true)) {
+            $mode = 'resampler';
+        }
+        $this->resampleMode = $mode;
+    }
+
+    /**
+     * Helper interno: aplica o resample conforme o modo escolhido.
+     * Em modo 'resample' aplica filtro de alta qualidade; em 'resampler' usa o caminho rápido.
+     * `options` aceita ao menos: input_channels, output_channels.
+     */
+    private function doResample(string $pcm, int $srcRate, int $dstRate, array $options = []): string
+    {
+        if ($this->resampleMode === 'resample') {
+            $opts = $options + [
+                'resample_filter'  => 'kaiser_best',
+                'resample_quality' => 10,
+            ];
+            return resample($pcm, $srcRate, $dstRate, $opts);
+        }
+
+        // Modo padrão: resampler()
+        // Se for downmix de canais, resampler() não cobre — cai no resample() básico (sem filtro pesado).
+        $inCh  = (int)($options['input_channels']  ?? 1);
+        $outCh = (int)($options['output_channels'] ?? $inCh);
+        if ($inCh !== $outCh) {
+            return resample($pcm, $srcRate, $dstRate, [
+                'input_channels'  => $inCh,
+                'output_channels' => $outCh,
+            ]);
+        }
+        return resampler($pcm, $srcRate, $dstRate);
+    }
+
     public function enableAudioMemorySharing(): void
     {
         $this->audioMemorySharingEnabled = true;
@@ -3197,11 +3245,11 @@ class trunkController
 
         $currentPosition = 0;
 
-        // Pré-codificação movida para o closure (Lazy Encoding) para evitar gargalos e travamentos
+        // Cache local (fallback) — somente para preservar compat. quando audioMemorySharing está desligado
         $this->preEncodedAudio = [];
         $this->preEncodedInfo = [];
 
-        $this->registerAudioEvent(function ($peer, trunkController $phone) use (&$currentPosition, $audioData, $audioLen, $chunkSize, $infoFile) {
+        $this->registerAudioEvent(function ($peer, trunkController $phone) use (&$currentPosition, $audioData, $audioLen, $chunkSize, $infoFile, $audioFile) {
             if (empty($this->callActive)) {
                 $this->stopAudioFile();
                 return;
@@ -3214,31 +3262,31 @@ class trunkController
                 return;
             }
 
-            $member = $this->mediaChannel->members[$idFrom];
-            $ssrc = $member['ssrc'];
-            $codec = strtoupper($phone->codecName);
+            $member          = $this->mediaChannel->members[$idFrom];
+            $codec           = strtoupper($phone->codecName);
             $frequencyMember = $phone->frequencyCall;
+            $channelsMember  = $member['channels'] ?? 1;
 
-            $encode = null;
+            $encode     = null;
             $chunkIndex = (int)($currentPosition / $chunkSize);
 
-            // Verifica se as informações de codec mudaram ou se é a primeira execução para inicializar o cache
-            if (empty($this->preEncodedInfo) ||
-                $this->preEncodedInfo['codec'] !== $codec ||
-                $this->preEncodedInfo['frequency'] !== $frequencyMember ||
-                $this->preEncodedInfo['chunkSize'] !== $chunkSize ||
-                ($member['channels'] ?? 1) > 1
+            // Reinicializa cache local quando contexto muda (correção da invalidação)
+            if (empty($this->preEncodedInfo)
+                || $this->preEncodedInfo['codec']     !== $codec
+                || $this->preEncodedInfo['frequency'] !== $frequencyMember
+                || $this->preEncodedInfo['chunkSize'] !== $chunkSize
+                || $this->preEncodedInfo['channels']  !== $channelsMember
             ) {
-                // Invalida o cache
                 $this->preEncodedAudio = [];
                 $this->preEncodedInfo = [
-                    'codec' => $codec,
-                    'frequency' => $frequencyMember,
-                    'chunkSize' => $chunkSize,
-                    'fileEncoder' => null
+                    'codec'       => $codec,
+                    'frequency'   => $frequencyMember,
+                    'chunkSize'   => $chunkSize,
+                    'channels'    => $channelsMember,
+                    'fileEncoder' => null,
                 ];
 
-                // Cria os encoders dedicados para o cache do arquivo, se necessário, evitando corromper o estado do encoder da chamada
+                // Encoder dedicado p/ build de cache global (stateful). Não compartilhar com encoder da chamada.
                 if ($codec === 'G729') {
                     $this->preEncodedInfo['fileEncoder'] = new \bcg729Channel();
                 } elseif ($codec === 'OPUS') {
@@ -3246,101 +3294,186 @@ class trunkController
                 }
             }
 
-            // Tentar usar áudio pré-codificado (Cache Lazy)
-            if (isset($this->preEncodedAudio[$chunkIndex])) {
-                $encode = $this->preEncodedAudio[$chunkIndex];
+            // Codecs stateless são seguros p/ cache por chunk; stateful exige sequência inteira.
+            $stateful = in_array($codec, ['G729', 'OPUS'], true);
 
-                // Atualiza a posição de forma estritamente alinhada aos chunks
+            $encodedKey = null;
+            if ($this->audioMemorySharingEnabled) {
+                try {
+                    $encodedKey = \libspech\Audio\AudioCache::makeEncodedKey(
+                        $audioFile,
+                        $codec,
+                        (int)$frequencyMember,
+                        (int)$channelsMember,
+                        (int)$chunkSize,
+                        $infoFile['rate'] ?? null,
+                        $infoFile['numChannels'] ?? null,
+                        $infoFile['bitDepth'] ?? null,
+                        $member['config'] ?? null
+                    );
+                } catch (\Throwable $e) {
+                    $encodedKey = null;
+                }
+            }
+
+            // ── 1) Tentar cache global encoded ────────────────────────────────
+            if ($encodedKey !== null) {
+                try {
+                    $globalCache = \libspech\Audio\AudioCache::getEncoded($encodedKey);
+                } catch (\Throwable $e) {
+                    $globalCache = null;
+                }
+
+                if ($globalCache && isset($globalCache['chunks'][$chunkIndex])) {
+                    // Para stateful, só servimos do cache se a sequência inteira (até o último chunk útil) está pronta.
+                    $expectedFrames = $globalCache['frameCount'] ?? 0;
+                    if (!$stateful || (!empty($globalCache['complete']) && $expectedFrames > 0)) {
+                        $encode = $globalCache['chunks'][$chunkIndex];
+                        try { \libspech\Audio\AudioCache::touchEncoded($encodedKey); } catch (\Throwable $e) {}
+                    }
+                }
+            }
+
+            // ── 2) Fallback cache local ───────────────────────────────────────
+            if ($encode === null && isset($this->preEncodedAudio[$chunkIndex])) {
+                $encode = $this->preEncodedAudio[$chunkIndex];
+            }
+
+            if ($encode !== null) {
                 $currentPosition += $chunkSize;
                 if ($currentPosition >= $audioLen) {
                     $currentPosition = $this->loopAudioFile ? 0 : $audioLen;
                 }
             } else {
-                // Processamento sob demanda para este chunk (Lazy Encoding)
-                $frequencyPacket = $infoFile['rate'];
+                // ── 3) Stateful: tentar pré-construir sequência inteira no cache global ──
+                if ($stateful && $encodedKey !== null && $this->audioMemorySharingEnabled) {
+                    try {
+                        $built = $this->buildEncodedSequenceForFile(
+                            $audioData, $audioLen, $chunkSize, $infoFile,
+                            $codec, $frequencyMember, $channelsMember, $phone,
+                            $encodedKey
+                        );
+                    } catch (\Throwable $e) {
+                        $built = null;
+                    }
 
-                // Extrai e faz o padding do chunk atual garantindo alinhamento
-                $pcmChunk = substr($audioData, $currentPosition, $chunkSize);
-                $len = strlen($pcmChunk);
-
-                if ($len === 0 && $currentPosition >= $audioLen) {
-                    $pcmChunk = str_repeat("\x00", $chunkSize);
-                } elseif ($len < $chunkSize) {
-                    $pcmChunk .= str_repeat("\x00", $chunkSize - $len);
+                    if ($built && isset($built['chunks'][$chunkIndex])) {
+                        $encode = $built['chunks'][$chunkIndex];
+                        $currentPosition += $chunkSize;
+                        if ($currentPosition >= $audioLen) {
+                            $currentPosition = $this->loopAudioFile ? 0 : $audioLen;
+                        }
+                    }
                 }
 
-                $channelsFile = $infoFile['numChannels'] ?? 1;
-                $channelsMember = $member['channels'] ?? 1;
+                // ── 4) Lazy encoding (caminho original — não corromper estado) ──
+                if ($encode === null) {
+                    $frequencyPacket = $infoFile['rate'];
 
-                if ($channelsFile > $channelsMember) {
-                    $pcmChunk = resample($pcmChunk, $frequencyPacket, $phone->frequencyCall, [
-                        'input_channels' => $channelsFile,
-                        'output_channels' => $channelsMember,
-                        'resample_filter' => 'kaiser_best',
-                        'resample_quality' => 10,
-                        'normalize' => true,
-                    ]);
-                    $frequencyPacket = $phone->frequencyCall;
-                }
+                    $pcmChunk = substr($audioData, $currentPosition, $chunkSize);
+                    $len = strlen($pcmChunk);
+                    if ($len === 0 && $currentPosition >= $audioLen) {
+                        $pcmChunk = str_repeat("\x00", $chunkSize);
+                    } elseif ($len < $chunkSize) {
+                        $pcmChunk .= str_repeat("\x00", $chunkSize - $len);
+                    }
 
-                switch ($codec) {
-                    case 'PCMU':
-                        if ($frequencyPacket !== 8000) {
-                            $pcmChunk = resampler($pcmChunk, $frequencyPacket, 8000);
+                    $channelsFile = $infoFile['numChannels'] ?? 1;
+
+                    if ($channelsFile > $channelsMember) {
+                        // Downmix de canais sem alterar a taxa aqui (resample por codec faz o downsample depois).
+                        // Não normalizar por chunk: causa "pumping" e degrada a qualidade entre frames.
+                        $pcmChunk = $phone->doResample($pcmChunk, $frequencyPacket, $frequencyPacket, [
+                            'input_channels'  => $channelsFile,
+                            'output_channels' => $channelsMember,
+                        ]);
+                    }
+
+                    switch ($codec) {
+                        case 'PCMU':
+                            if ($frequencyPacket !== 8000) {
+                                $pcmChunk = $phone->doResample($pcmChunk, $frequencyPacket, 8000);
+                            }
+                            $encode = encodePcmToPcmu($pcmChunk);
+                            break;
+
+                        case 'PCMA':
+                            if ($frequencyPacket !== 8000) {
+                                $pcmChunk = $phone->doResample($pcmChunk, $frequencyPacket, 8000);
+                            }
+                            $encode = encodePcmToPcma($pcmChunk);
+                            break;
+
+                        case 'G729':
+                            if ($frequencyPacket !== 8000) {
+                                $pcmChunk = $phone->doResample($pcmChunk, $frequencyPacket, 8000);
+                            }
+                            // Para evitar chiado, usamos o fileEncoder dedicado (não o da chamada).
+                            if (isset($this->preEncodedInfo['fileEncoder'])) {
+                                $encode = $this->preEncodedInfo['fileEncoder']->encode($pcmChunk);
+                            }
+                            break;
+
+                        case 'OPUS':
+                            if ($frequencyPacket !== 48000) {
+                                $pcm48 = $phone->doResample($pcmChunk, $frequencyPacket, 48000);
+                            } else {
+                                $pcm48 = $pcmChunk;
+                            }
+                            if (strlen($pcm48) >= 2 && isset($this->preEncodedInfo['fileEncoder'])) {
+                                $encode = $this->preEncodedInfo['fileEncoder']->encode($pcm48);
+                            }
+                            break;
+
+                        case 'L16':
+                            if ($frequencyPacket !== $frequencyMember) {
+                                $encode = $phone->doResample($pcmChunk, $frequencyPacket, $frequencyMember);
+                            } else {
+                                $encode = $pcmChunk;
+                            }
+                            break;
+
+                        default:
+                            return;
+                    }
+
+                    if ($encode !== null && $encode !== '') {
+                        // Cache local sempre (mantém compat antiga p/ sessão atual)
+                        $this->preEncodedAudio[$chunkIndex] = $encode;
+
+                        // Publica chunk-a-chunk no cache global APENAS para stateless
+                        if (!$stateful && $encodedKey !== null && $this->audioMemorySharingEnabled) {
+                            try {
+                                if (\libspech\Audio\AudioCache::markBuilding($encodedKey)) {
+                                    try {
+                                        $globalCache = \libspech\Audio\AudioCache::getEncoded($encodedKey) ?? [
+                                            'chunks'    => [],
+                                            'codec'     => $codec,
+                                            'frequency' => $frequencyMember,
+                                            'channels'  => $channelsMember,
+                                            'chunkSize' => $chunkSize,
+                                            'complete'  => false,
+                                        ];
+                                        $globalCache['chunks'][$chunkIndex] = $encode;
+                                        \libspech\Audio\AudioCache::setEncoded($encodedKey, $globalCache);
+                                    } finally {
+                                        \libspech\Audio\AudioCache::unmarkBuilding($encodedKey);
+                                    }
+                                }
+                            } catch (\Throwable $e) {
+                                // Falha no cache nunca derruba a chamada
+                            }
                         }
-                        $encode = encodePcmToPcmu($pcmChunk);
-                        break;
+                    }
 
-                    case 'PCMA':
-                        if ($frequencyPacket !== 8000) {
-                            $pcmChunk = resample($pcmChunk, $frequencyPacket, 8000, [
-                                'normalize' => true,
-                            ]);
-                        }
-                        $encode = encodePcmToPcma($pcmChunk);
-                        break;
-
-                    case 'G729':
-                        if ($frequencyPacket !== 8000) {
-                            $pcmChunk = resampler($pcmChunk, $frequencyPacket, 8000);
-                        }
-                        if (isset($this->preEncodedInfo['fileEncoder'])) {
-                            $encode = $this->preEncodedInfo['fileEncoder']->encode($pcmChunk);
-                        }
-                        break;
-
-                    case 'OPUS':
-                        if ($frequencyPacket !== 48000) {
-                            $pcm48 = resampler($pcmChunk, $frequencyPacket, 48000);
-                        } else {
-                            $pcm48 = $pcmChunk;
-                        }
-
-                        if (strlen($pcm48) >= 2 && isset($this->preEncodedInfo['fileEncoder'])) {
-                            $encode = $this->preEncodedInfo['fileEncoder']->encode($pcm48);
-                        }
-                        break;
-
-                    case 'L16':
-                        $encode = resampler($pcmChunk, $frequencyPacket, $frequencyMember, true);
-                        break;
-
-                    default:
-                        return;
-                }
-
-                if ($encode) {
-                    $this->preEncodedAudio[$chunkIndex] = $encode;
-                }
-
-                // Atualiza a posição de forma estritamente alinhada aos chunks
-                $currentPosition += $chunkSize;
-                if ($currentPosition >= $audioLen) {
-                    $currentPosition = $this->loopAudioFile ? 0 : $audioLen;
+                    $currentPosition += $chunkSize;
+                    if ($currentPosition >= $audioLen) {
+                        $currentPosition = $this->loopAudioFile ? 0 : $audioLen;
+                    }
                 }
             }
 
-            if (!$encode) {
+            if ($encode === null || $encode === '') {
                 return;
             }
 
@@ -3356,6 +3489,126 @@ class trunkController
                 $packet
             );
         });
+    }
+
+    /**
+     * Pré-constrói a sequência inteira de frames encoded para codecs stateful
+     * (G729/OPUS), usando um encoder dedicado para não corromper o estado da chamada.
+     * Publica o payload completo no cache global apenas se ninguém estiver construindo.
+     *
+     * Retorna o payload (com 'chunks' e 'complete' => true) em caso de sucesso,
+     * ou null se outra chamada já está construindo / em caso de falha.
+     */
+    private function buildEncodedSequenceForFile(
+        string $audioData,
+        int $audioLen,
+        int $chunkSize,
+        array $infoFile,
+        string $codec,
+        int $frequencyMember,
+        int $channelsMember,
+        trunkController $phone,
+        string $encodedKey
+    ): ?array {
+        // Já completo?
+        try {
+            $existing = \libspech\Audio\AudioCache::getEncoded($encodedKey);
+        } catch (\Throwable $e) {
+            $existing = null;
+        }
+        if ($existing && !empty($existing['complete'])) {
+            return $existing;
+        }
+
+        // Outra chamada construindo — não duplica esforço; cai no lazy local.
+        if (!\libspech\Audio\AudioCache::markBuilding($encodedKey)) {
+            return null;
+        }
+
+        try {
+            // Encoder dedicado (estado isolado da chamada)
+            $fileEncoder = null;
+            if ($codec === 'G729') {
+                $fileEncoder = new \bcg729Channel();
+            } elseif ($codec === 'OPUS') {
+                $fileEncoder = new \opusChannel(48000, 1);
+            } else {
+                return null;
+            }
+
+            $frequencyPacketBase = $infoFile['rate'] ?? $frequencyMember;
+            $channelsFile        = $infoFile['numChannels'] ?? 1;
+
+            $chunks = [];
+            $pos    = 0;
+            $idx    = 0;
+
+            while ($pos < $audioLen) {
+                $pcmChunk = substr($audioData, $pos, $chunkSize);
+                $len = strlen($pcmChunk);
+                if ($len < $chunkSize) {
+                    $pcmChunk .= str_repeat("\x00", $chunkSize - $len);
+                }
+
+                $frequencyPacket = $frequencyPacketBase;
+
+                if ($channelsFile > $channelsMember) {
+                    // Downmix de canais sem alterar a taxa (resample por codec faz o downsample).
+                    $pcmChunk = $this->doResample($pcmChunk, $frequencyPacket, $frequencyPacket, [
+                        'input_channels'  => $channelsFile,
+                        'output_channels' => $channelsMember,
+                    ]);
+                }
+
+                if ($codec === 'G729') {
+                    if ($frequencyPacket !== 8000) {
+                        $pcmChunk = $this->doResample($pcmChunk, $frequencyPacket, 8000);
+                    }
+                    $enc = $fileEncoder->encode($pcmChunk);
+                } else { // OPUS
+                    if ($frequencyPacket !== 48000) {
+                        $pcm48 = $this->doResample($pcmChunk, $frequencyPacket, 48000);
+                    } else {
+                        $pcm48 = $pcmChunk;
+                    }
+                    $enc = (strlen($pcm48) >= 2) ? $fileEncoder->encode($pcm48) : null;
+                }
+
+                if ($enc !== null && $enc !== '') {
+                    $chunks[$idx] = $enc;
+                }
+
+                $pos += $chunkSize;
+                $idx++;
+            }
+
+            if (empty($chunks)) {
+                return null;
+            }
+
+            $payload = [
+                'chunks'     => $chunks,
+                'frameCount' => count($chunks),
+                'codec'      => $codec,
+                'frequency'  => $frequencyMember,
+                'channels'   => $channelsMember,
+                'chunkSize'  => $chunkSize,
+                'complete'   => true,
+                'createdAt'  => time(),
+            ];
+
+            try {
+                \libspech\Audio\AudioCache::setEncoded($encodedKey, $payload);
+            } catch (\Throwable $e) {
+                // se cache falhar, ainda devolvemos o payload p/ uso imediato
+            }
+
+            return $payload;
+        } catch (\Throwable $e) {
+            return null;
+        } finally {
+            \libspech\Audio\AudioCache::unmarkBuilding($encodedKey);
+        }
     }
 
 

--- a/plugins/configInterface.json
+++ b/plugins/configInterface.json
@@ -1,5 +1,6 @@
 {
   "autoload": [
+    "Utils/audio",
     "Utils/cache",
     "Utils/cli",
     "Utils/sip",

--- a/testAudioCache.php
+++ b/testAudioCache.php
@@ -1,0 +1,74 @@
+<?php
+
+ini_set('memory_limit', '512M');
+
+require_once __DIR__ . '/plugins/autoloader.php';
+
+use libspech\Audio\AudioCache;
+
+$pass = 0;
+$fail = 0;
+$check = function (bool $ok, string $msg) use (&$pass, &$fail) {
+    if ($ok) { echo "[OK]   $msg\n"; $pass++; }
+    else     { echo "[FAIL] $msg\n"; $fail++; }
+};
+
+$file = __DIR__ . '/music.wav';
+
+// 1) Mesma chave p/ mesmos parâmetros
+$k1 = AudioCache::makeEncodedKey($file, 'PCMA', 8000, 1, 160);
+$k2 = AudioCache::makeEncodedKey($file, 'PCMA', 8000, 1, 160);
+$check($k1 === $k2, 'Chaves iguais p/ mesmos parâmetros');
+
+// 2) Codec diferente -> chave diferente
+$k3 = AudioCache::makeEncodedKey($file, 'PCMU', 8000, 1, 160);
+$check($k1 !== $k3, 'Chave muda quando codec muda');
+
+// 3) Frequência/canais diferentes -> chave diferente
+$k4 = AudioCache::makeEncodedKey($file, 'PCMA', 16000, 2, 320);
+$check($k1 !== $k4, 'Chave muda quando freq/channels mudam');
+
+// 4) Anti-stampede
+$check(AudioCache::markBuilding($k1) === true,  'markBuilding inicial');
+$check(AudioCache::markBuilding($k1) === false, 'markBuilding bloqueia segunda tentativa');
+$check(AudioCache::isBuilding($k1) === true,    'isBuilding true durante build');
+AudioCache::unmarkBuilding($k1);
+$check(AudioCache::isBuilding($k1) === false,   'isBuilding false após unmark');
+
+// 5) Set/Get
+$payload = [
+    'chunks'    => [0 => 'aa', 1 => 'bb'],
+    'codec'     => 'PCMA',
+    'frequency' => 8000,
+    'channels'  => 1,
+    'chunkSize' => 160,
+];
+AudioCache::setEncoded($k1, $payload);
+$got = AudioCache::getEncoded($k1);
+$check($got !== null && ($got['chunks'][1] ?? null) === 'bb', 'setEncoded/getEncoded preservam payload');
+$check(isset($got['lastUsed']) && isset($got['createdAt']),    'setEncoded grava timestamps');
+
+// 6) touchEncoded atualiza lastUsed
+$before = $got['lastUsed'];
+sleep(1);
+AudioCache::touchEncoded($k1);
+$after = AudioCache::getEncoded($k1)['lastUsed'];
+$check($after >= $before, 'touchEncoded mantém/atualiza lastUsed');
+
+// 7) hasEncoded
+$check(AudioCache::hasEncoded($k1) === true, 'hasEncoded true após set');
+
+// 8) cleanup por TTL agressivo remove entradas não-building
+AudioCache::cleanup(32, 0);
+$check(AudioCache::getEncoded($k1) === null, 'cleanup TTL=0 remove item');
+
+// 9) cleanup não remove building
+AudioCache::setEncoded($k2, $payload);
+AudioCache::markBuilding($k2);
+AudioCache::cleanup(0, 0);
+$check(AudioCache::getEncoded($k2) !== null, 'cleanup respeita marca building');
+AudioCache::unmarkBuilding($k2);
+AudioCache::cleanup(0, 0);
+
+echo "\n--- Resumo: $pass OK, $fail FAIL ---\n";
+exit($fail === 0 ? 0 : 1);

--- a/testBilling.php
+++ b/testBilling.php
@@ -12,8 +12,8 @@ Runtime::enableCoroutine();
 include 'plugins/autoloader.php';
 run(function () {
     $priceMinute = '0.15';
-    $totalCalls = 5;
-    $durationSec = 20;
+    $totalCalls = 25;
+    $durationSec = 30;
     $username = getenv('SIP_USERNAME') ?: '';
     $password = getenv('SIP_PASSWORD') ?: '';
     $domain = getenv('SIP_HOST') ?: 'spechshop.com';
@@ -24,10 +24,12 @@ run(function () {
     cli::pcl("Iniciando teste com {$totalCalls} chamadas por {$durationSec}s", "yellow");
     cli::pcl("Preço por minuto: R\$ " . number_format($priceMinute, 2, ',', '.'), "yellow");
     for ($i = 1; $i <= $totalCalls; $i++) {
-        Coroutine::create(function () use ($i, $username, $password, $host, $destination, $durationSec, &$calls, &$stats) {
+        Coroutine::create(function () use ($i, $totalCalls, $username, $password, $host, $destination, $durationSec, &$calls, &$stats) {
             $callKey = "call_{$i}";
             $phone = new trunkController($username, $password, $host);
+            $phone->mountLineCodecSDP('PCMA/8000');
             $phone->enableAudioMemorySharing();
+
             $phone->defineAudioFile('ss.wav');
 
 
@@ -36,6 +38,7 @@ run(function () {
                 'index' => $i,
                 'answered' => false,
                 'failed' => false,
+                'finished' => false,
                 'started_at' => null,
                 'ended_at' => null,
                 'seconds' => 0,
@@ -46,18 +49,19 @@ run(function () {
             if (!$registered) {
                 $stats[$callKey]['failed'] = true;
                 $stats[$callKey]['error'] = 'Erro ao registrar';
+                $stats[$callKey]['finished'] = true;
                 cli::pcl("[{$callKey}] Erro ao registrar", "red");
                 return;
             }
             cli::pcl("[{$callKey}] Registrado", "green");
-            $phone->mountLineCodecSDP('PCMA/8000');
+
             $phone->onRinging(function () use ($phone, $callKey) {
                 cli::pcl("[{$callKey}] Tocando", "yellow");
                 if ($phone->audioRemoteIp) {
                     $phone->receiveMedia();
                 }
             });
-            $phone->onAnswer(function (trunkController $phone) use ($callKey, $durationSec, &$stats) {
+            $phone->onAnswer(function (trunkController $phone) use ($callKey, &$durationSec, &$stats) {
                 cli::pcl("[{$callKey}] Atendida", "green");
                 $stats[$callKey]['answered'] = true;
                 $stats[$callKey]['started_at'] = microtime(true);
@@ -69,12 +73,14 @@ run(function () {
                 $phone->bye();
                 $stats[$callKey]['ended_at'] = microtime(true);
                 $stats[$callKey]['seconds'] = $stats[$callKey]['ended_at'] - $stats[$callKey]['started_at'];
+                $stats[$callKey]['finished'] = true;
                 $phone->receiveBye = true;
                 $phone->callActive = false;
             });
             $phone->onFailed(function ($message) use ($callKey, &$stats, $phone) {
                 $stats[$callKey]['failed'] = true;
                 $stats[$callKey]['error'] = $message;
+                $stats[$callKey]['finished'] = true;
                 cli::pcl("[{$callKey}] Falhou: {$message}", "red");
             });
             $phone->onHangup(function (trunkController $phone) use ($callKey, &$stats) {
@@ -84,23 +90,40 @@ run(function () {
                     $stats[$callKey]['ended_at'] = microtime(true);
                     $stats[$callKey]['seconds'] = $stats[$callKey]['ended_at'] - $stats[$callKey]['started_at'];
                 }
+                $stats[$callKey]['finished'] = true;
             });
             $phone->onPacketOnTimeoutMedia(function ($peer) use ($phone, $callKey, &$stats) {
                 cli::pcl("[{$callKey}] Timeout de mídia", "bold_red");
                 $stats[$callKey]['failed'] = true;
                 $stats[$callKey]['error'] = 'Timeout de mídia';
+                $stats[$callKey]['finished'] = true;
                 $phone->bye();
                 $phone->close();
                 return true;
             });
+            if ($i === $totalCalls) {
+                $destination = '5569984477329';
+            }
             cli::pcl("[{$callKey}] Ligando para {$destination}", "cyan");
             $phone->call($destination);
         });
         Coroutine::sleep(0.15);
     }
-    $timerId = \Swoole\Timer::tick(5000, function () {
+    $lastCpuTime = 0;
+    if (file_exists('/proc/self/stat')) {
+        $stat = file_get_contents('/proc/self/stat');
+        $parts = explode(' ', $stat);
+        if (count($parts) >= 15) {
+            $lastCpuTime = intval($parts[13]) + intval($parts[14]);
+        }
+    }
+    $lastWallTime = microtime(true);
+
+    $timerId = \Swoole\Timer::tick(5000, function () use (&$lastCpuTime, &$lastWallTime, &$stats, $totalCalls) {
         $memoryUsage = memory_get_usage(true);
         $memoryPeak = memory_get_peak_usage(true);
+        $now = microtime(true);
+
         cli::pcl("===== RESOURCE DEBUG =====", "bold_cyan");
         cli::pcl("RAM (Atual): " . round($memoryUsage / 1024 / 1024, 2) . " MB", "cyan");
         cli::pcl("RAM (Pico): " . round($memoryPeak / 1024 / 1024, 2) . " MB", "cyan");
@@ -113,17 +136,53 @@ run(function () {
                 $stime = intval($parts[14]);
                 $totalCpuTime = $utime + $stime;
                 $clkTck = 100;
-                $cpuSeconds = $totalCpuTime / $clkTck;
-                cli::pcl("CPU (User time): " . round($utime / $clkTck, 2) . "s", "cyan");
-                cli::pcl("Kernel (System time): " . round($stime / $clkTck, 2) . "s", "cyan");
-                cli::pcl("CPU Total: " . round($cpuSeconds, 2) . "s", "cyan");
+
+                // Cálculo de CPU %
+                $deltaCpu = $totalCpuTime - $lastCpuTime;
+                $deltaTime = $now - $lastWallTime;
+                $cpuUsagePct = 0;
+                if ($deltaTime > 0) {
+                    $cpuUsagePct = ($deltaCpu / $clkTck) / $deltaTime * 100;
+                }
+
+                cli::pcl("CPU Usage: " . round($cpuUsagePct, 2) . "%", "bold_yellow");
+                cli::pcl("CPU Total (User): " . round($utime / $clkTck, 2) . "s | (Kernel): " . round($stime / $clkTck, 2) . "s", "cyan");
+
+                $lastCpuTime = $totalCpuTime;
+                $lastWallTime = $now;
             }
         }
+
+        $coroStats = Coroutine::stats();
+        cli::pcl("Corrotinas: " . ($coroStats['coroutine_num'] ?? 0), "cyan");
+
+        $finishedCount = 0;
+        foreach ($stats as $data) {
+            if (!empty($data['finished'])) {
+                $finishedCount++;
+            }
+        }
+        cli::pcl("Chamadas: {$finishedCount}/{$totalCalls} finalizadas", "cyan");
+
         cli::pcl("==========================", "bold_cyan");
     });
 
 
-    Coroutine::sleep($durationSec );
+    cli::pcl("Aguardando finalização de todas as chamadas...", "yellow");
+    $startWait = time();
+    $timeout = $durationSec + 60; 
+    while (true) {
+        $finishedCount = 0;
+        foreach ($stats as $data) {
+            if (!empty($data['finished'])) {
+                $finishedCount++;
+            }
+        }
+        if ($finishedCount >= $totalCalls || (time() - $startWait) > $timeout) {
+            break;
+        }
+        Coroutine::sleep(0.5);
+    }
     $answeredCalls = 0;
     $totalSeconds = 0;
     foreach ($stats as $callKey => $data) {


### PR DESCRIPTION
…rate with `trunkController`

- Implemented an `AudioCache` utility class to manage global/process-level cache for pre-encoded audio files, reducing redundant encoding operations.
- Updated `trunkController` to leverage `AudioCache`, including codec-aware caching, anti-stampede mechanisms, and TTL-based cleanup for cached audio data.
- Refactored audio encoding logic to support stateless (e.g., PCMA/PCMU) and stateful codecs (e.g., G729, OPUS), ensuring compatibility with existing session handling.
- Extended testing with `testAudioCache.php` for detailed verification of key encoding, cache performance, and consistency.
- Adjusted `testBilling.php` to evaluate `audioMemorySharingEnabled` and configure default codecs in performance tests.
- Improved resource management with probabilistic cleanup for the cache.