### PR TITLE
feat: detectar humano e caixa postal após 200 OK

### DIFF
--- a/example.php
+++ b/example.php
@@ -61,7 +61,7 @@ include 'plugins/autoloader.php';
         // ====================================================================
         // SESSÃO 5: CONFIGURAÇÃO DE ÁUDIO E AMD
         // ====================================================================
-        $phone->mountLineCodecSDP('PCMU/8000');
+        $phone->mountLineCodecSDP('G729/8000');
         // $phone->mountLineCodecSDP('OPUS/48000/2');
 
         $phone->enableAudioRecording();
@@ -231,7 +231,7 @@ include 'plugins/autoloader.php';
 
         $phone->onAnswer(
             function (trunkController $phone) use ($detector): void {
-                $detector->markAnswered();
+
 
                 cli::pcl('Chamada recebida', 'green');
                 cli::pcl(
@@ -243,6 +243,7 @@ include 'plugins/autoloader.php';
                 // SESSÃO 7: FLUXO DE INTERAÇÃO NA CHAMADA
                 // ============================================================
                 $phone->waitSilence(false, 10);
+                $detector->markAnswered();
 
                 $buffer = $phone->getBuffer();
                 $bufferLen = $buffer->length();
@@ -300,7 +301,7 @@ include 'plugins/autoloader.php';
         // ====================================================================
         // SESSÃO 8: ORIGINAÇÃO
         // ====================================================================
-        $phone->call('5569984477329');
+        $phone->call('553140040104');
 
         $detector->finish('call_returned');
         cli::pcl("Chamada originada", 'bold_green');

--- a/example.php
+++ b/example.php
@@ -300,9 +300,10 @@ include 'plugins/autoloader.php';
         // ====================================================================
         // SESSÃO 8: ORIGINAÇÃO
         // ====================================================================
-        $phone->call('5569992388165');
+        $phone->call('5569984477329');
 
         $detector->finish('call_returned');
+        cli::pcl("Chamada originada", 'bold_green');
 
         $phone->saveBufferToWavFile(
             'rec.wav',

--- a/example.php
+++ b/example.php
@@ -14,88 +14,59 @@
 // ============================================================================
 // SESSÃO 1: CONFIGURAÇÕES INICIAIS
 // ============================================================================
-// Aumenta o limite de memória para 1GB - necessário para processar áudio
 ini_set('memory_limit', '1024M');
 
-// Importa as classes necessárias do sistema
 use libspech\audio\EarlyGreetingDetector;
 use libspech\Cli\cli;
 use libspech\Sip\trunkController;
 use function libspech\Sip\interruptibleSleep;
 
-// Habilita o suporte a corotinas do Swoole para execução assíncrona
 \Swoole\Runtime::enableCoroutine();
 
-
-// Carrega o autoloader para importar todas as dependências do projeto
 include 'plugins/autoloader.php';
-
 
 // ============================================================================
 // SESSÃO 2: INICIALIZAÇÃO DO AMBIENTE DE COROTINA
 // ============================================================================
-// Cria o ambiente de execução em corotina do Swoole
-\Swoole\Coroutine\run(function () {
-    // Cria uma nova corotina para executar o código SIP de forma assíncrona
-    \Swoole\Coroutine::create(function () {
-
-        // $s=microtime(true);
-        // usleep(500_000);
-        // $c = round(microtime(true)-$s,3);
-        // cli::pcl("Corotina SIP iniciada em {$c} segundos", "bold_green");
-        // exit;
+\Swoole\Coroutine\run(function (): void {
+    \Swoole\Coroutine::create(function (): void {
         // ====================================================================
         // SESSÃO 3: CONFIGURAÇÃO DE CREDENCIAIS SIP
         // ====================================================================
-        // Busca as credenciais SIP das variáveis de ambiente
-        // Se não estiverem definidas, usa strings vazias como fallback
         $username = getenv('SIP_USERNAME') ?: '';
         $password = getenv('SIP_PASSWORD') ?: '';
         $domain = getenv('SIP_HOST') ?: 'spechshop.com';
 
+        $host = filter_var($domain, FILTER_VALIDATE_IP)
+            ? $domain
+            : gethostbyname($domain);
 
-        // Valida se o domínio é um IP ou hostname
-        // Se for hostname, resolve para IP usando DNS
-        if (!filter_var($domain, FILTER_VALIDATE_IP)) {
-            $host = gethostbyname($domain);
-        } else {
-            $host = $domain;
-        }
-
-        // Instancia o controlador do trunk SIP com as credenciais
         $phone = new trunkController($username, $password, $host);
-        //$phone->enableVAD();
-        //$phone->voiceActivityTimeout(3);
 
+        // $phone->enableVAD();
+        // $phone->voiceActivityTimeout(3);
+        // $phone->setCallerId('xxxxxxxxxxx');
 
-        //$phone->setCallerId('xxxxxxxxxxx');
         // ====================================================================
         // SESSÃO 4: REGISTRO SIP
         // ====================================================================
-        // Tenta registrar no servidor SIP com timeout de 10 segundos
-        // Se falhar, lança uma exceção e interrompe a execução
-        if ($phone->register(5)) {
-            cli::pcl("Registrado com sucesso", "green");
-        } else {
-            cli::pcl("Erro ao registrar", "red");
-            return false;
+        if (!$phone->register(5)) {
+            cli::pcl('Erro ao registrar', 'red');
+
+            return;
         }
 
-        // ====================================================================
-        // SESSÃO 5: CONFIGURAÇÃO DE CALLBACKS DE EVENTOS
-        // ====================================================================
+        cli::pcl('Registrado com sucesso', 'green');
 
-
+        // ====================================================================
+        // SESSÃO 5: CONFIGURAÇÃO DE ÁUDIO E AMD
+        // ====================================================================
         $phone->mountLineCodecSDP('PCMU/8000');
-        //$phone->mountLineCodecSDP('OPUS/48000/2');
+        // $phone->mountLineCodecSDP('OPUS/48000/2');
+
         $phone->enableAudioRecording();
         $phone->enableAudioMemorySharing();
         $phone->defineAudioFile('silence_5m.wav');
-
-        // Habilita a gravação de áudio durante a chamada
-
-
-        // Callback executado quando uma chamada está tocando (ringing)
 
         $detector = new EarlyGreetingDetector(
             sampleRate: 8000,
@@ -105,10 +76,12 @@ include 'plugins/autoloader.php';
             maximumInternalGapMs: 120,
             minimumVoiceDbfs: -42.0,
             noiseMarginDb: 10.0,
+            humanMinimumSpeechMs: 200,
+            humanMaximumSpeechMs: 1200,
+            humanSilenceAfterSpeechMs: 600,
+            machineGreetingVoiceMs: 2000,
+            postAnswerAnalysisTimeoutMs: 6000,
         );
-
-
-
 
         $detector->onGreetingDetected(
             function (array $event): void {
@@ -120,127 +93,235 @@ include 'plugins/autoloader.php';
             }
         );
 
-        $detector->onVoiceEnd(
+        $detector->onVoiceStart(
             function (array $event): void {
-                if ( $event['greeting_detected'])
                 printf(
-                    "[%8.3f s] Voz finalizada | voz=%d ms | saudacao=%s\n",
+                    "[%8.3f s] Voz iniciada | fase=%s | RMS=%.2f dBFS\n",
                     $event['audio_ms'] / 1000,
-                    $event['voiced_ms'],
-                    $event['greeting_detected'] ? 'SIM' : 'NAO'
+                    $event['phase'],
+                    $event['rms_dbfs']
                 );
             }
         );
 
+        $detector->onVoiceEnd(
+            function (array $event): void {
+                printf(
+                    "[%8.3f s] Voz finalizada | fase=%s | voz=%d ms | segmentos=%d | motivo=%s\n",
+                    $event['audio_ms'] / 1000,
+                    $event['phase'],
+                    $event['voiced_ms'],
+                    $event['speech_segments'] ?? 1,
+                    $event['reason']
+                );
+            }
+        );
 
+        $detector->onAnswerBoundary(
+            function (array $event): void {
+                printf(
+                    "[%8.3f s] 200 OK | saudacao_early=%s | voz_cruzou_200=%s | voz_early=%d ms\n",
+                    $event['audio_ms'] / 1000,
+                    $event['greeting_detected'] ? 'SIM' : 'NAO',
+                    $event['voice_crossed_answer'] ? 'SIM' : 'NAO',
+                    $event['early_voice_ms']
+                );
+            }
+        );
 
+        $detector->onHumanLikely(
+            function (array $event): void {
+                printf(
+                    "[%8.3f s] AMD: HUMANO PROVAVEL | motivo=%s | ultima_fala=%d ms | silencio=%d ms\n",
+                    $event['audio_ms'] / 1000,
+                    $event['reason'],
+                    $event['last_speech_ms'],
+                    $event['silence_after_speech_ms']
+                );
+            }
+        );
 
-        $phone->onReceivePcm(function (string $pcmData, array $peer, trunkController $phone) use ($detector): void {
-            $detector->push($pcmData);
+        $detector->onMachineLikely(
+            function (array $event): void {
+                printf(
+                    "[%8.3f s] AMD: CAIXA POSTAL PROVAVEL | motivo=%s | maior_fala=%d ms | voz_total=%d ms\n",
+                    $event['audio_ms'] / 1000,
+                    $event['reason'],
+                    $event['longest_voice_ms'],
+                    $event['total_voice_ms']
+                );
+            }
+        );
+
+        $detector->onUnknown(
+            function (array $event): void {
+                printf(
+                    "[%8.3f s] AMD: INDETERMINADO | motivo=%s | segmentos=%d | voz_total=%d ms\n",
+                    $event['audio_ms'] / 1000,
+                    $event['reason'],
+                    $event['speech_segments'],
+                    $event['total_voice_ms']
+                );
+            }
+        );
+
+        $detector->onAmdResult(
+            function (array $event): void {
+                printf(
+                    "[%8.3f s] RESULTADO AMD=%s | motivo=%s | pos_200=%d ms | early=%s\n",
+                    $event['audio_ms'] / 1000,
+                    strtoupper($event['classification']),
+                    $event['reason'],
+                    $event['post_answer_ms'],
+                    $event['early_greeting_detected'] ? 'SIM' : 'NAO'
+                );
+            }
+        );
+
+        // ====================================================================
+        // SESSÃO 6: CALLBACKS SIP/RTP
+        // ====================================================================
+        $phone->onReceivePcm(
+            function (
+                string $pcmData,
+                array $peer,
+                trunkController $phone
+            ) use ($detector): void {
+                $detector->push($pcmData);
+            }
+        );
+
+        $phone->onRinging(function () use ($phone): void {
+            cli::pcl(
+                $phone->lastPacket['method'] . ' Chamada TOCANDO ' . microtime(true),
+                'yellow'
+            );
         });
-        $phone->onRinging(function () use (&$phone) {
-            cli::pcl($phone->lastPacket['method'] . " Chamada TOCANDO " . microtime(true), "yellow");
-            //\Swoole\Coroutine::sleep(5);
-            //$phone->cancel();
-        });
-        $phone->onFailed(function ($message) use ( $phone) {
-            cli::pcl("Chamada falhou: $message", "red");
 
-        });
-        $phone->onHangup(function (trunkController $phone) {
-            // Salva o buffer de áudio gravado em um arquivo WAV
-            $phone->saveBufferToWavFile('rec.wav', $phone->getBuffer());
-            // Desbloqueia a corotina para continuar a execução
+        $phone->onFailed(
+            function ($message) use ($phone, $detector): void {
+                $detector->finish('call_failed');
+                cli::pcl("Chamada falhou: {$message}", 'red');
+            }
+        );
 
-            cli::pcl("Bye recebido", "red");
+        $phone->onHangup(
+            function (trunkController $phone) use ($detector): void {
+                $detector->finish('hangup');
 
-        });
-        $phone->onSdpReceived(function (trunkController $phone) {
-            cli::pcl("SDP recebido " . microtime(true), "green");
+                $phone->saveBufferToWavFile(
+                    'rec.wav',
+                    $phone->getBuffer()
+                );
+
+                $result = $detector->getAmdResult() ?? 'sem_resultado';
+                $reason = $detector->getAmdReason() ?? 'sem_motivo';
+
+                cli::pcl(
+                    "Bye recebido | AMD={$result} | motivo={$reason}",
+                    'red'
+                );
+            }
+        );
+
+        $phone->onSdpReceived(function (trunkController $phone): void {
+            cli::pcl('SDP recebido ' . microtime(true), 'green');
             $phone->receiveMedia();
         });
-        $phone->onAnswer(function (trunkController $phone) use ($detector) {
-            $detector->markAnswered();
 
+        $phone->onAnswer(
+            function (trunkController $phone) use ($detector): void {
+                $detector->markAnswered();
 
+                cli::pcl('Chamada recebida', 'green');
+                cli::pcl(
+                    'IP remoto: ' . $phone->audioRemoteIp . ':' . $phone->audioRemotePort,
+                    'yellow'
+                );
 
-            cli::pcl("Chamada recebida", "green");
+                // ============================================================
+                // SESSÃO 7: FLUXO DE INTERAÇÃO NA CHAMADA
+                // ============================================================
+                $phone->waitSilence(false, 10);
 
-            cli::pcl("IP remoto: " . $phone->audioRemoteIp . ':' . $phone->audioRemotePort, "yellow");
-            // Inicia o recebimento de mídia (áudio RTP)
+                $buffer = $phone->getBuffer();
+                $bufferLen = $buffer->length();
 
+                cli::pcl("Buffer atual: {$bufferLen} bytes", 'yellow');
 
-            // ================================================================
-            // SESSÃO 7: FLUXO DE INTERAÇÃO NA CHAMADA
-            // ================================================================
+                $phone->send2833('#');
 
-            // Aguarda 10 segundos de forma interruptível (pode ser cancelado se receber BYE)
+                $cpf = '42017165204';
+                interruptibleSleep(3, $phone->receiveBye);
 
+                foreach (str_split(substr($cpf, 0, 11)) as $digit) {
+                    $phone->send2833($digit);
+                    cli::pcl("Digitando: {$digit}", 'yellow');
+                }
 
-            // Envia DTMF (tom de teclado) - caractere '*' com duração de 160ms
+                cli::pcl("Digitado: {$cpf}", 'green');
 
+                $phone->waitSilence(false, 10);
+                interruptibleSleep(3, $phone->receiveBye);
 
-            $phone->waitSilence(false, 10);
+                $phone->bye();
+                $phone->close();
 
-
-            $buffer = $phone->getBuffer();
-            $bufferLen = $buffer->length();
-
-
-            $phone->send2833('#');
-
-
-            $cpf = '42017165204';
-            interruptibleSleep(3, $phone->receiveBye);
-            foreach (str_split(substr($cpf, 0, 11)) as $digit) {
-                $phone->send2833($digit);
-                cli::pcl("Digitando: " . $digit, "yellow");
+                $phone->receiveBye = true;
+                $phone->callActive = false;
             }
-            cli::pcl("Digitado: " . $cpf, "green");
-            $phone->waitSilence(false, 10);
+        );
 
-            interruptibleSleep(3, $phone->receiveBye);
+        $phone->onKeyPress(
+            function ($event, $peer) use ($phone): void {
+                cli::pcl(
+                    "{$phone->calledNumber} Digitou: {$event}",
+                    'yellow'
+                );
+            }
+        );
 
+        $phone->onPacketOnTimeoutMedia(
+            function ($peer) use ($phone, $detector): bool {
+                $detector->finish('media_timeout');
 
-            $phone->bye();
-            $phone->close();
+                cli::pcl(
+                    'Timeout de mídia atingido, encerrando chamada',
+                    'bold_red'
+                );
 
-            // Define flags indicando que a chamada foi encerrada
-            $phone->receiveBye = true;
-            $phone->callActive = false;
-        });
-        $phone->onKeyPress(function ($event, $peer) use ($phone) {
-            cli::pcl("$phone->calledNumber Digitou: " . $event, "yellow");
-        });
-        $phone->onPacketOnTimeoutMedia(function ($peer) use ($phone) {
-            cli::pcl("Timeout de mídia atingido, encerrando chamada", 'bold_red');
-            $phone->bye();
-            $phone->close();
-            return true;
-        });
+                $phone->bye();
+                $phone->close();
 
+                return true;
+            }
+        );
 
-        //$phone->enableStereoSound();
-
-
+        // ====================================================================
+        // SESSÃO 8: ORIGINAÇÃO
+        // ====================================================================
         $phone->call('5569992388165');
 
+        $detector->finish('call_returned');
 
-        $phone->saveBufferToWavFile('rec.wav', $phone->getBuffer());
-
+        $phone->saveBufferToWavFile(
+            'rec.wav',
+            $phone->getBuffer()
+        );
 
         // ====================================================================
         // SESSÃO 9: FINALIZAÇÃO E LIMPEZA
         // ====================================================================
-        cli::pcl("Script finalizado", "green");
+        cli::pcl(
+            'Script finalizado | AMD=' . ($detector->getAmdResult() ?? 'sem_resultado') .
+            ' | motivo=' . ($detector->getAmdReason() ?? 'sem_motivo'),
+            'green'
+        );
 
-        // Fecha a conexão SIP e libera recursos
         $phone->close();
 
-        cli::pcl("Processo cancelado", "red");
+        cli::pcl('Processo cancelado', 'red');
     });
 });
 
-// Mensagem final indicando que o processo de corotina foi encerrado
-cli::pcl("Processo encerrado com sucesso", "green");
-
+cli::pcl('Processo encerrado com sucesso', 'green');

--- a/plugins/Utils/audio/EarlyGreetingDetector.php
+++ b/plugins/Utils/audio/EarlyGreetingDetector.php
@@ -11,12 +11,9 @@ final class EarlyGreetingDetector
 {
     private string $frameBuffer = '';
     private string $analysisBuffer = '';
-
     private int $frameBytes;
     private int $analysisWindowBytes;
-
     private int $elapsedMs = 0;
-
     private bool $answered = false;
     private ?int $answeredAtMs = null;
 
@@ -26,10 +23,18 @@ final class EarlyGreetingDetector
     private int $voiceGapMs = 0;
     private bool $greetingReported = false;
     private bool $earlyGreetingDetected = false;
+    private bool $earlyAnnouncementDetected = false;
+    private int $earlySpeechSegments = 0;
+    private int $earlyTotalVoiceMs = 0;
+    private ?int $earlyAnnouncementStartedAtMs = null;
+    private int $earlyLastVoiceEndedAtMs = 0;
+    private int $earlyAnnouncementSpanMs = 0;
 
     private int $postAnswerElapsedMs = 0;
     private bool $postAnswerVoiceActive = false;
     private int $postAnswerVoiceStartedAtMs = 0;
+    private ?int $postAnswerFirstVoiceStartedAtMs = null;
+    private int $postAnswerLastVoiceEndedAtMs = 0;
     private int $postAnswerCurrentVoiceMs = 0;
     private int $postAnswerCurrentGapMs = 0;
     private int $postAnswerLastSpeechMs = 0;
@@ -39,10 +44,10 @@ final class EarlyGreetingDetector
     private int $postAnswerLongestVoiceMs = 0;
     private bool $voiceCrossedAnswer = false;
     private int $earlyVoiceAtAnswerMs = 0;
+    private bool $announcementContinuedAfterAnswer = false;
 
     private ?string $amdResult = null;
     private ?string $amdReason = null;
-
     private float $noiseFloorDbfs = -65.0;
 
     private ?Closure $onVoiceStart = null;
@@ -70,307 +75,164 @@ final class EarlyGreetingDetector
         private readonly int $humanSilenceAfterSpeechMs = 600,
         private readonly int $machineGreetingVoiceMs = 2000,
         private readonly int $postAnswerAnalysisTimeoutMs = 6000,
+        private readonly int $earlyAnnouncementMinimumSegments = 3,
+        private readonly int $earlyAnnouncementMinimumVoiceMs = 800,
+        private readonly int $earlyAnnouncementMinimumSpanMs = 1500,
+        private readonly int $postAnswerInternalGapMs = 400,
+        private readonly int $postAnswerMachineMinimumSegments = 3,
+        private readonly int $postAnswerMachineMinimumVoiceMs = 800,
+        private readonly int $postAnswerMachineMinimumSpanMs = 1500,
+        private readonly int $earlyToAnswerMaximumGapMs = 1200,
+        private readonly int $answerToPostVoiceMaximumGapMs = 500,
     ) {
-        if ($this->sampleRate <= 0) {
-            throw new InvalidArgumentException('sampleRate deve ser maior que zero.');
+        if ($sampleRate <= 0 || $frameDurationMs <= 0) {
+            throw new InvalidArgumentException('sampleRate e frameDurationMs devem ser maiores que zero.');
+        }
+        if ($analysisWindowMs < $frameDurationMs) {
+            throw new InvalidArgumentException('analysisWindowMs deve ser maior ou igual a frameDurationMs.');
+        }
+        if ($humanMinimumSpeechMs < 0 || $humanMaximumSpeechMs < $humanMinimumSpeechMs) {
+            throw new InvalidArgumentException('Faixa de fala humana inválida.');
+        }
+        if ($machineGreetingVoiceMs <= 0 || $postAnswerAnalysisTimeoutMs <= 0) {
+            throw new InvalidArgumentException('Limites de análise devem ser maiores que zero.');
+        }
+        if ($earlyAnnouncementMinimumSegments <= 0 || $earlyAnnouncementMinimumVoiceMs <= 0 || $earlyAnnouncementMinimumSpanMs <= 0) {
+            throw new InvalidArgumentException('Limites de anúncio early media inválidos.');
+        }
+        if ($postAnswerInternalGapMs < $frameDurationMs || $postAnswerMachineMinimumSegments <= 0 || $postAnswerMachineMinimumVoiceMs <= 0 || $postAnswerMachineMinimumSpanMs <= 0) {
+            throw new InvalidArgumentException('Limites de análise pós-atendimento inválidos.');
+        }
+        if ($earlyToAnswerMaximumGapMs < 0 || $answerToPostVoiceMaximumGapMs < 0) {
+            throw new InvalidArgumentException('Intervalos de continuidade não podem ser negativos.');
         }
 
-        if ($this->frameDurationMs <= 0) {
-            throw new InvalidArgumentException('frameDurationMs deve ser maior que zero.');
-        }
-
-        if ($this->analysisWindowMs < $this->frameDurationMs) {
-            throw new InvalidArgumentException(
-                'analysisWindowMs deve ser maior ou igual a frameDurationMs.'
-            );
-        }
-
-        if ($this->humanMinimumSpeechMs < 0) {
-            throw new InvalidArgumentException('humanMinimumSpeechMs não pode ser negativo.');
-        }
-
-        if ($this->humanMaximumSpeechMs < $this->humanMinimumSpeechMs) {
-            throw new InvalidArgumentException(
-                'humanMaximumSpeechMs deve ser maior ou igual a humanMinimumSpeechMs.'
-            );
-        }
-
-        if ($this->machineGreetingVoiceMs <= 0) {
-            throw new InvalidArgumentException('machineGreetingVoiceMs deve ser maior que zero.');
-        }
-
-        if ($this->postAnswerAnalysisTimeoutMs <= 0) {
-            throw new InvalidArgumentException(
-                'postAnswerAnalysisTimeoutMs deve ser maior que zero.'
-            );
-        }
-
-        $frameSamples = (int) round(
-            $this->sampleRate * ($this->frameDurationMs / 1000)
-        );
-
-        $analysisSamples = (int) round(
-            $this->sampleRate * ($this->analysisWindowMs / 1000)
-        );
-
-        // PCM16 mono: 2 bytes por amostra.
-        $this->frameBytes = $frameSamples * 2;
-        $this->analysisWindowBytes = $analysisSamples * 2;
+        $this->frameBytes = (int) round($sampleRate * ($frameDurationMs / 1000)) * 2;
+        $this->analysisWindowBytes = (int) round($sampleRate * ($analysisWindowMs / 1000)) * 2;
     }
 
-    public function onVoiceStart(callable $callback): self
-    {
-        $this->onVoiceStart = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onVoiceEnd(callable $callback): self
-    {
-        $this->onVoiceEnd = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onGreetingDetected(callable $callback): self
-    {
-        $this->onGreetingDetected = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onAnalysis(callable $callback): self
-    {
-        $this->onAnalysis = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onAnswerBoundary(callable $callback): self
-    {
-        $this->onAnswerBoundary = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onHumanLikely(callable $callback): self
-    {
-        $this->onHumanLikely = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onMachineLikely(callable $callback): self
-    {
-        $this->onMachineLikely = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onUnknown(callable $callback): self
-    {
-        $this->onUnknown = Closure::fromCallable($callback);
-
-        return $this;
-    }
-
-    public function onAmdResult(callable $callback): self
-    {
-        $this->onAmdResult = Closure::fromCallable($callback);
-
-        return $this;
-    }
+    public function onVoiceStart(callable $callback): self { $this->onVoiceStart = Closure::fromCallable($callback); return $this; }
+    public function onVoiceEnd(callable $callback): self { $this->onVoiceEnd = Closure::fromCallable($callback); return $this; }
+    public function onGreetingDetected(callable $callback): self { $this->onGreetingDetected = Closure::fromCallable($callback); return $this; }
+    public function onAnalysis(callable $callback): self { $this->onAnalysis = Closure::fromCallable($callback); return $this; }
+    public function onAnswerBoundary(callable $callback): self { $this->onAnswerBoundary = Closure::fromCallable($callback); return $this; }
+    public function onHumanLikely(callable $callback): self { $this->onHumanLikely = Closure::fromCallable($callback); return $this; }
+    public function onMachineLikely(callable $callback): self { $this->onMachineLikely = Closure::fromCallable($callback); return $this; }
+    public function onUnknown(callable $callback): self { $this->onUnknown = Closure::fromCallable($callback); return $this; }
+    public function onAmdResult(callable $callback): self { $this->onAmdResult = Closure::fromCallable($callback); return $this; }
 
     public function push(string $pcmData): void
     {
-        if ($pcmData === '') {
-            return;
-        }
-
+        if ($pcmData === '') return;
         $this->frameBuffer .= $pcmData;
-
         while (strlen($this->frameBuffer) >= $this->frameBytes) {
             $frame = substr($this->frameBuffer, 0, $this->frameBytes);
             $this->frameBuffer = substr($this->frameBuffer, $this->frameBytes);
-
             $this->processFrame($frame);
         }
     }
 
     public function markAnswered(): void
     {
-        if ($this->answered) {
-            return;
-        }
+        if ($this->answered) return;
+
+        $crossedVoiceMs = $this->voiceActive ? $this->voiceFramesMs : 0;
+        if ($this->voiceActive) $this->finishEarlyVoiceSegment('answer_boundary');
 
         $this->answered = true;
         $this->answeredAtMs = $this->elapsedMs;
-        $this->postAnswerElapsedMs = 0;
-        $this->voiceCrossedAnswer = $this->voiceActive;
-        $this->earlyVoiceAtAnswerMs = $this->voiceActive
-            ? $this->voiceFramesMs
-            : 0;
+        $this->voiceCrossedAnswer = $crossedVoiceMs > 0;
+        $this->earlyVoiceAtAnswerMs = $crossedVoiceMs;
 
         if ($this->voiceCrossedAnswer) {
             $this->postAnswerVoiceActive = true;
             $this->postAnswerVoiceStartedAtMs = $this->elapsedMs;
+            $this->postAnswerFirstVoiceStartedAtMs = $this->elapsedMs;
             $this->postAnswerSpeechSegments = 1;
-            $this->postAnswerCurrentVoiceMs = 0;
-            $this->postAnswerCurrentGapMs = 0;
+            $this->announcementContinuedAfterAnswer = $this->earlyAnnouncementDetected;
         }
 
         $event = [
             'audio_ms' => $this->elapsedMs,
-            'early_voice_active' => $this->voiceActive,
-            'early_voice_started_ms' => $this->voiceActive
-                ? $this->voiceStartedAtMs
-                : null,
-            'early_voice_ms' => $this->voiceFramesMs,
+            'early_voice_active' => $this->voiceCrossedAnswer,
+            'early_voice_started_ms' => $this->earlyAnnouncementStartedAtMs,
+            'early_voice_ms' => $this->earlyTotalVoiceMs,
+            'early_active_voice_ms' => $crossedVoiceMs,
+            'early_speech_segments' => $this->earlySpeechSegments,
+            'early_announcement_span_ms' => $this->earlyAnnouncementSpanMs,
+            'early_last_voice_ended_at_ms' => $this->earlyLastVoiceEndedAtMs,
+            'early_gap_to_answer_ms' => $this->earlyLastVoiceEndedAtMs > 0 ? max(0, $this->elapsedMs - $this->earlyLastVoiceEndedAtMs) : null,
+            'early_announcement_detected' => $this->earlyAnnouncementDetected,
             'greeting_detected' => $this->earlyGreetingDetected,
             'voice_crossed_answer' => $this->voiceCrossedAnswer,
         ];
-
-        if ($this->onAnswerBoundary !== null) {
-            ($this->onAnswerBoundary)($event);
-        }
+        if ($this->onAnswerBoundary) ($this->onAnswerBoundary)($event);
     }
 
     public function finish(string $reason = 'finished'): void
     {
-        if (!$this->answered && $this->voiceActive) {
-            $this->finishEarlyVoiceSegment($reason);
-        }
-
-        if ($this->answered && $this->postAnswerVoiceActive) {
-            $this->finishPostAnswerVoiceSegment($reason);
-        }
-
-        if ($this->answered && $this->amdResult === null) {
-            $this->emitAmdResult('unknown', $reason);
-        }
+        if (!$this->answered && $this->voiceActive) $this->finishEarlyVoiceSegment($reason);
+        if ($this->answered && $this->postAnswerVoiceActive) $this->finishPostAnswerVoiceSegment($reason);
+        if ($this->answered && $this->amdResult === null) $this->evaluatePostAnswerMachine();
+        if ($this->answered && $this->amdResult === null) $this->emitAmdResult('unknown', $reason);
     }
 
-    public function isGreetingDetected(): bool
-    {
-        return $this->earlyGreetingDetected;
-    }
-
-    public function isAnswered(): bool
-    {
-        return $this->answered;
-    }
-
-    public function getAnsweredAtMs(): ?int
-    {
-        return $this->answeredAtMs;
-    }
-
-    public function getAmdResult(): ?string
-    {
-        return $this->amdResult;
-    }
-
-    public function getAmdReason(): ?string
-    {
-        return $this->amdReason;
-    }
+    public function isGreetingDetected(): bool { return $this->earlyGreetingDetected; }
+    public function isAnswered(): bool { return $this->answered; }
+    public function getAnsweredAtMs(): ?int { return $this->answeredAtMs; }
+    public function getAmdResult(): ?string { return $this->amdResult; }
+    public function getAmdReason(): ?string { return $this->amdReason; }
 
     private function processFrame(string $frame): void
     {
         $frameStartMs = $this->elapsedMs;
         $this->elapsedMs += $this->frameDurationMs;
-
         $this->analysisBuffer .= $frame;
-
         if (strlen($this->analysisBuffer) > $this->analysisWindowBytes) {
-            $this->analysisBuffer = substr(
-                $this->analysisBuffer,
-                -$this->analysisWindowBytes
-            );
+            $this->analysisBuffer = substr($this->analysisBuffer, -$this->analysisWindowBytes);
         }
 
-        $frameSamples = $this->decodePcm16LittleEndian($frame);
-
-        if ($frameSamples === []) {
-            return;
-        }
-
-        $rmsDbfs = $this->calculateRmsDbfs($frameSamples);
-
-        $tone425 = [
-            'detected' => false,
-            'frequency_hz' => 0.0,
-            'level_dbfs' => -120.0,
-            'prominence_db' => 0.0,
-        ];
-
+        $samples = $this->decodePcm16LittleEndian($frame);
+        if ($samples === []) return;
+        $rmsDbfs = $this->calculateRmsDbfs($samples);
+        $tone425 = ['detected' => false, 'frequency_hz' => 0.0, 'level_dbfs' => -120.0, 'prominence_db' => 0.0];
         if (strlen($this->analysisBuffer) >= $this->analysisWindowBytes) {
-            $analysisSamples = $this->decodePcm16LittleEndian(
-                $this->analysisBuffer
-            );
-
-            $tone425 = $this->analyzeTone425($analysisSamples);
+            $tone425 = $this->analyzeTone425($this->decodePcm16LittleEndian($this->analysisBuffer));
         }
 
-        $voiceThresholdDbfs = max(
-            $this->minimumVoiceDbfs,
-            $this->noiseFloorDbfs + $this->noiseMarginDb
-        );
-
-        // O tom de ringback não deve ser contado como voz.
-        $isVoice =
-            $rmsDbfs >= $voiceThresholdDbfs &&
-            !$tone425['detected'];
-
-        if (
-            !$isVoice &&
-            !$tone425['detected'] &&
-            $rmsDbfs < -40.0
-        ) {
-            $this->noiseFloorDbfs =
-                ($this->noiseFloorDbfs * 0.98) +
-                ($rmsDbfs * 0.02);
+        $threshold = max($this->minimumVoiceDbfs, $this->noiseFloorDbfs + $this->noiseMarginDb);
+        $isVoice = $rmsDbfs >= $threshold && !$tone425['detected'];
+        if (!$isVoice && !$tone425['detected'] && $rmsDbfs < -40.0) {
+            $this->noiseFloorDbfs = ($this->noiseFloorDbfs * 0.98) + ($rmsDbfs * 0.02);
         }
 
         $analysis = [
             'audio_ms' => $frameStartMs,
-            'phase' => $this->answered
-                ? 'answered'
-                : 'early_media',
+            'phase' => $this->answered ? 'answered' : 'early_media',
             'rms_dbfs' => $rmsDbfs,
             'noise_floor_dbfs' => $this->noiseFloorDbfs,
-            'voice_threshold_dbfs' => $voiceThresholdDbfs,
+            'voice_threshold_dbfs' => $threshold,
             'voice' => $isVoice,
             'tone_425' => $tone425,
+            'early_speech_segments' => $this->earlySpeechSegments,
+            'early_total_voice_ms' => $this->earlyTotalVoiceMs,
+            'early_announcement_detected' => $this->earlyAnnouncementDetected,
+            'post_answer_speech_segments' => $this->postAnswerSpeechSegments,
+            'post_answer_total_voice_ms' => $this->postAnswerTotalVoiceMs,
+            'announcement_continued_after_answer' => $this->announcementContinuedAfterAnswer,
             'amd_result' => $this->amdResult,
         ];
-
-        if ($this->onAnalysis !== null) {
-            ($this->onAnalysis)($analysis);
-        }
+        if ($this->onAnalysis) ($this->onAnalysis)($analysis);
 
         if (!$this->answered) {
-            $this->updateEarlyVoiceState(
-                isVoice: $isVoice,
-                frameStartMs: $frameStartMs,
-                analysis: $analysis
-            );
-
+            $this->updateEarlyVoiceState($isVoice, $frameStartMs, $analysis);
             return;
         }
-
-        $this->updatePostAnswerState(
-            isVoice: $isVoice,
-            frameStartMs: $frameStartMs,
-            analysis: $analysis
-        );
+        $this->updatePostAnswerState($isVoice, $frameStartMs, $analysis);
     }
 
-    private function updateEarlyVoiceState(
-        bool $isVoice,
-        int $frameStartMs,
-        array $analysis
-    ): void {
+    private function updateEarlyVoiceState(bool $isVoice, int $frameStartMs, array $analysis): void
+    {
         if ($isVoice) {
             if (!$this->voiceActive) {
                 $this->voiceActive = true;
@@ -378,213 +240,218 @@ final class EarlyGreetingDetector
                 $this->voiceFramesMs = 0;
                 $this->voiceGapMs = 0;
                 $this->greetingReported = false;
-
-                if ($this->onVoiceStart !== null) {
-                    ($this->onVoiceStart)([
-                        'audio_ms' => $frameStartMs,
-                        'rms_dbfs' => $analysis['rms_dbfs'],
-                        'phase' => 'early_media',
-                    ]);
-                }
+                $this->earlyAnnouncementStartedAtMs ??= $frameStartMs;
+                if ($this->onVoiceStart) ($this->onVoiceStart)(['audio_ms' => $frameStartMs, 'rms_dbfs' => $analysis['rms_dbfs'], 'phase' => 'early_media']);
             }
-
             $this->voiceFramesMs += $this->frameDurationMs;
             $this->voiceGapMs = 0;
-
-            if (
-                !$this->greetingReported &&
-                $this->voiceFramesMs >= $this->minimumGreetingVoiceMs
-            ) {
+            if (!$this->greetingReported && $this->voiceFramesMs >= $this->minimumGreetingVoiceMs) {
                 $this->greetingReported = true;
-                $this->earlyGreetingDetected = true;
-
-                if ($this->onGreetingDetected !== null) {
-                    ($this->onGreetingDetected)([
-                        'audio_ms' => $frameStartMs,
-                        'started_at_ms' => $this->voiceStartedAtMs,
-                        'voiced_ms' => $this->voiceFramesMs,
-                        'phase' => 'early_media',
-                        'classification' => 'early_greeting',
-                    ]);
-                }
+                $this->reportEarlyAnnouncement('early_greeting', $frameStartMs + $this->frameDurationMs);
             }
-
+            $this->evaluateEarlyAnnouncement($frameStartMs + $this->frameDurationMs);
             return;
         }
 
-        if (!$this->voiceActive) {
-            return;
-        }
-
+        if (!$this->voiceActive) return;
         $this->voiceGapMs += $this->frameDurationMs;
-
-        if ($this->voiceGapMs <= $this->maximumInternalGapMs) {
-            return;
-        }
-
-        $this->finishEarlyVoiceSegment('silence');
+        if ($this->voiceGapMs > $this->maximumInternalGapMs) $this->finishEarlyVoiceSegment('silence');
     }
 
     private function finishEarlyVoiceSegment(string $reason): void
     {
-        if (!$this->voiceActive) {
-            return;
-        }
+        if (!$this->voiceActive) return;
+        $endedAtMs = max($this->voiceStartedAtMs, $this->elapsedMs - $this->voiceGapMs);
+        $this->earlySpeechSegments++;
+        $this->earlyTotalVoiceMs += $this->voiceFramesMs;
+        $this->earlyLastVoiceEndedAtMs = $endedAtMs;
+        $this->earlyAnnouncementStartedAtMs ??= $this->voiceStartedAtMs;
+        $this->earlyAnnouncementSpanMs = max(0, $endedAtMs - $this->earlyAnnouncementStartedAtMs);
 
         $event = [
             'audio_ms' => $this->elapsedMs,
             'started_at_ms' => $this->voiceStartedAtMs,
+            'ended_at_ms' => $endedAtMs,
             'voiced_ms' => $this->voiceFramesMs,
             'gap_ms' => $this->voiceGapMs,
             'greeting_detected' => $this->greetingReported,
+            'early_announcement_detected' => $this->earlyAnnouncementDetected,
+            'early_speech_segments' => $this->earlySpeechSegments,
+            'early_total_voice_ms' => $this->earlyTotalVoiceMs,
+            'early_announcement_span_ms' => $this->earlyAnnouncementSpanMs,
+            'speech_segments' => $this->earlySpeechSegments,
             'reason' => $reason,
             'phase' => 'early_media',
         ];
-
-        if ($this->onVoiceEnd !== null) {
-            ($this->onVoiceEnd)($event);
-        }
+        if ($this->onVoiceEnd) ($this->onVoiceEnd)($event);
 
         $this->voiceActive = false;
         $this->voiceStartedAtMs = 0;
         $this->voiceFramesMs = 0;
         $this->voiceGapMs = 0;
         $this->greetingReported = false;
+        $this->evaluateEarlyAnnouncement($endedAtMs);
     }
 
-    private function updatePostAnswerState(
-        bool $isVoice,
-        int $frameStartMs,
-        array $analysis
-    ): void {
-        if ($this->answeredAtMs === null) {
-            return;
+    private function evaluateEarlyAnnouncement(int $endMs): void
+    {
+        if ($this->earlyAnnouncementDetected || $this->earlyAnnouncementStartedAtMs === null) return;
+        $segments = $this->earlySpeechSegments + ($this->voiceActive ? 1 : 0);
+        $voiceMs = $this->earlyTotalVoiceMs + ($this->voiceActive ? $this->voiceFramesMs : 0);
+        $spanMs = max(0, $endMs - $this->earlyAnnouncementStartedAtMs);
+        if ($segments >= $this->earlyAnnouncementMinimumSegments && $voiceMs >= $this->earlyAnnouncementMinimumVoiceMs && $spanMs >= $this->earlyAnnouncementMinimumSpanMs) {
+            $this->reportEarlyAnnouncement('early_announcement', $endMs);
         }
+    }
 
-        $this->postAnswerElapsedMs = max(
-            0,
-            $this->elapsedMs - $this->answeredAtMs
-        );
-
-        if ($this->amdResult !== null) {
-            return;
+    private function reportEarlyAnnouncement(string $classification, int $endMs): void
+    {
+        if ($this->earlyAnnouncementDetected) return;
+        $segments = $this->earlySpeechSegments + ($this->voiceActive ? 1 : 0);
+        $voiceMs = $this->earlyTotalVoiceMs + ($this->voiceActive ? $this->voiceFramesMs : 0);
+        $startedAtMs = $this->earlyAnnouncementStartedAtMs ?? $this->voiceStartedAtMs;
+        $spanMs = max(0, $endMs - $startedAtMs);
+        $this->earlyGreetingDetected = true;
+        $this->earlyAnnouncementDetected = true;
+        $this->earlyAnnouncementSpanMs = max($this->earlyAnnouncementSpanMs, $spanMs);
+        if ($this->onGreetingDetected) {
+            ($this->onGreetingDetected)([
+                'audio_ms' => $endMs,
+                'started_at_ms' => $startedAtMs,
+                'voiced_ms' => $voiceMs,
+                'total_voice_ms' => $voiceMs,
+                'speech_segments' => $segments,
+                'span_ms' => $spanMs,
+                'phase' => 'early_media',
+                'classification' => $classification,
+            ]);
         }
+    }
+
+    private function updatePostAnswerState(bool $isVoice, int $frameStartMs, array $analysis): void
+    {
+        if ($this->answeredAtMs === null) return;
+        $this->postAnswerElapsedMs = max(0, $this->elapsedMs - $this->answeredAtMs);
+        if ($this->amdResult !== null) return;
 
         if ($isVoice) {
             if (!$this->postAnswerVoiceActive) {
                 $this->postAnswerVoiceActive = true;
                 $this->postAnswerVoiceStartedAtMs = $frameStartMs;
+                $this->postAnswerFirstVoiceStartedAtMs ??= $frameStartMs;
                 $this->postAnswerCurrentVoiceMs = 0;
                 $this->postAnswerCurrentGapMs = 0;
                 $this->postAnswerSilenceAfterSpeechMs = 0;
                 $this->postAnswerSpeechSegments++;
-
-                if ($this->onVoiceStart !== null) {
-                    ($this->onVoiceStart)([
-                        'audio_ms' => $frameStartMs,
-                        'post_answer_ms' => $this->postAnswerElapsedMs,
-                        'rms_dbfs' => $analysis['rms_dbfs'],
-                        'phase' => 'answered',
-                    ]);
-                }
+                $this->evaluateAnnouncementContinuation($frameStartMs);
+                if ($this->onVoiceStart) ($this->onVoiceStart)(['audio_ms' => $frameStartMs, 'post_answer_ms' => $this->postAnswerElapsedMs, 'rms_dbfs' => $analysis['rms_dbfs'], 'phase' => 'answered']);
             }
-
             $this->postAnswerCurrentVoiceMs += $this->frameDurationMs;
             $this->postAnswerTotalVoiceMs += $this->frameDurationMs;
             $this->postAnswerCurrentGapMs = 0;
             $this->postAnswerSilenceAfterSpeechMs = 0;
-            $this->postAnswerLongestVoiceMs = max(
-                $this->postAnswerLongestVoiceMs,
-                $this->postAnswerCurrentVoiceMs
-            );
-
-            $continuousVoiceMs =
-                $this->postAnswerCurrentVoiceMs +
-                ($this->voiceCrossedAnswer ? $this->earlyVoiceAtAnswerMs : 0);
-
-            if ($continuousVoiceMs >= $this->machineGreetingVoiceMs) {
+            $this->postAnswerLongestVoiceMs = max($this->postAnswerLongestVoiceMs, $this->postAnswerCurrentVoiceMs);
+            $continuousMs = $this->postAnswerCurrentVoiceMs + ($this->voiceCrossedAnswer ? $this->earlyVoiceAtAnswerMs : 0);
+            if ($continuousMs >= $this->machineGreetingVoiceMs) {
                 $this->emitAmdResult('machine_likely', 'long_greeting');
-
                 return;
             }
+            if ($this->evaluatePostAnswerMachine()) return;
         } elseif ($this->postAnswerVoiceActive) {
             $this->postAnswerCurrentGapMs += $this->frameDurationMs;
-
-            if ($this->postAnswerCurrentGapMs > $this->maximumInternalGapMs) {
-                $this->finishPostAnswerVoiceSegment('silence');
-            }
+            if ($this->postAnswerCurrentGapMs > $this->postAnswerInternalGapMs) $this->finishPostAnswerVoiceSegment('silence');
         } elseif ($this->postAnswerSpeechSegments > 0) {
             $this->postAnswerSilenceAfterSpeechMs += $this->frameDurationMs;
-
             if (
+                !$this->earlyAnnouncementDetected &&
                 !$this->voiceCrossedAnswer &&
+                !$this->announcementContinuedAfterAnswer &&
                 $this->postAnswerSpeechSegments === 1 &&
                 $this->postAnswerLastSpeechMs >= $this->humanMinimumSpeechMs &&
                 $this->postAnswerLastSpeechMs <= $this->humanMaximumSpeechMs &&
                 $this->postAnswerSilenceAfterSpeechMs >= $this->humanSilenceAfterSpeechMs
             ) {
-                $this->emitAmdResult(
-                    'human_likely',
-                    'short_greeting_followed_by_silence'
-                );
-
+                $this->emitAmdResult('human_likely', 'short_greeting_followed_by_silence');
                 return;
             }
         }
 
-        if (
-            $this->amdResult === null &&
-            $this->postAnswerElapsedMs >= $this->postAnswerAnalysisTimeoutMs
-        ) {
+        if ($this->amdResult === null && $this->postAnswerElapsedMs >= $this->postAnswerAnalysisTimeoutMs) {
             $this->emitAmdResult('unknown', 'analysis_timeout');
         }
     }
 
     private function finishPostAnswerVoiceSegment(string $reason): void
     {
-        if (!$this->postAnswerVoiceActive) {
-            return;
-        }
-
+        if (!$this->postAnswerVoiceActive) return;
+        $endedAtMs = max($this->postAnswerVoiceStartedAtMs, $this->elapsedMs - $this->postAnswerCurrentGapMs);
         $this->postAnswerLastSpeechMs = $this->postAnswerCurrentVoiceMs;
-        $this->postAnswerLongestVoiceMs = max(
-            $this->postAnswerLongestVoiceMs,
-            $this->postAnswerLastSpeechMs
-        );
+        $this->postAnswerLastVoiceEndedAtMs = $endedAtMs;
+        $this->postAnswerLongestVoiceMs = max($this->postAnswerLongestVoiceMs, $this->postAnswerLastSpeechMs);
 
         $event = [
             'audio_ms' => $this->elapsedMs,
             'post_answer_ms' => $this->postAnswerElapsedMs,
             'started_at_ms' => $this->postAnswerVoiceStartedAtMs,
+            'ended_at_ms' => $endedAtMs,
             'voiced_ms' => $this->postAnswerLastSpeechMs,
             'gap_ms' => $this->postAnswerCurrentGapMs,
             'speech_segments' => $this->postAnswerSpeechSegments,
+            'total_voice_ms' => $this->postAnswerTotalVoiceMs,
+            'greeting_span_ms' => $this->getPostAnswerGreetingSpanMs(),
             'greeting_detected' => false,
             'voice_crossed_answer' => $this->voiceCrossedAnswer,
+            'announcement_continued_after_answer' => $this->announcementContinuedAfterAnswer,
             'reason' => $reason,
             'phase' => 'answered',
         ];
-
-        if ($this->onVoiceEnd !== null) {
-            ($this->onVoiceEnd)($event);
-        }
+        if ($this->onVoiceEnd) ($this->onVoiceEnd)($event);
 
         $this->postAnswerVoiceActive = false;
         $this->postAnswerVoiceStartedAtMs = 0;
         $this->postAnswerCurrentVoiceMs = 0;
         $this->postAnswerCurrentGapMs = 0;
         $this->postAnswerSilenceAfterSpeechMs = 0;
+        $this->evaluatePostAnswerMachine();
+    }
+
+    private function evaluateAnnouncementContinuation(int $voiceStartedAtMs): void
+    {
+        if ($this->announcementContinuedAfterAnswer || !$this->earlyAnnouncementDetected || $this->answeredAtMs === null || $this->earlyLastVoiceEndedAtMs <= 0) return;
+        $earlyGap = max(0, $this->answeredAtMs - $this->earlyLastVoiceEndedAtMs);
+        $postGap = max(0, $voiceStartedAtMs - $this->answeredAtMs);
+        if ($earlyGap <= $this->earlyToAnswerMaximumGapMs && $postGap <= $this->answerToPostVoiceMaximumGapMs) {
+            $this->announcementContinuedAfterAnswer = true;
+        }
+    }
+
+    private function evaluatePostAnswerMachine(): bool
+    {
+        if ($this->amdResult !== null) return true;
+        $spanMs = $this->getPostAnswerGreetingSpanMs();
+        if (
+            $this->postAnswerSpeechSegments < $this->postAnswerMachineMinimumSegments ||
+            $this->postAnswerTotalVoiceMs < $this->postAnswerMachineMinimumVoiceMs ||
+            $spanMs < $this->postAnswerMachineMinimumSpanMs
+        ) return false;
+
+        $reason = $this->announcementContinuedAfterAnswer ? 'early_announcement_continued_after_answer' : 'multi_segment_greeting';
+        $this->emitAmdResult('machine_likely', $reason);
+        return true;
+    }
+
+    private function getPostAnswerGreetingSpanMs(): int
+    {
+        if ($this->postAnswerFirstVoiceStartedAtMs === null) return 0;
+        $endMs = $this->postAnswerVoiceActive ? $this->elapsedMs : $this->postAnswerLastVoiceEndedAtMs;
+        return $endMs > 0 ? max(0, $endMs - $this->postAnswerFirstVoiceStartedAtMs) : 0;
     }
 
     private function emitAmdResult(string $classification, string $reason): void
     {
-        if ($this->amdResult !== null) {
-            return;
-        }
-
+        if ($this->amdResult !== null) return;
         $this->amdResult = $classification;
         $this->amdReason = $reason;
-
         $event = [
             'audio_ms' => $this->elapsedMs,
             'answered_at_ms' => $this->answeredAtMs,
@@ -593,257 +460,108 @@ final class EarlyGreetingDetector
             'reason' => $reason,
             'voice_crossed_answer' => $this->voiceCrossedAnswer,
             'early_greeting_detected' => $this->earlyGreetingDetected,
+            'early_announcement_detected' => $this->earlyAnnouncementDetected,
             'early_voice_at_answer_ms' => $this->earlyVoiceAtAnswerMs,
+            'early_speech_segments' => $this->earlySpeechSegments,
+            'early_total_voice_ms' => $this->earlyTotalVoiceMs,
+            'early_announcement_span_ms' => $this->earlyAnnouncementSpanMs,
+            'early_last_voice_ended_at_ms' => $this->earlyLastVoiceEndedAtMs,
+            'announcement_continued_after_answer' => $this->announcementContinuedAfterAnswer,
             'speech_segments' => $this->postAnswerSpeechSegments,
             'current_speech_ms' => $this->postAnswerCurrentVoiceMs,
             'last_speech_ms' => $this->postAnswerLastSpeechMs,
             'total_voice_ms' => $this->postAnswerTotalVoiceMs,
             'longest_voice_ms' => $this->postAnswerLongestVoiceMs,
+            'greeting_span_ms' => $this->getPostAnswerGreetingSpanMs(),
             'silence_after_speech_ms' => $this->postAnswerSilenceAfterSpeechMs,
         ];
-
-        if ($this->onAmdResult !== null) {
-            ($this->onAmdResult)($event);
-        }
-
-        if ($classification === 'human_likely' && $this->onHumanLikely !== null) {
-            ($this->onHumanLikely)($event);
-
-            return;
-        }
-
-        if ($classification === 'machine_likely' && $this->onMachineLikely !== null) {
-            ($this->onMachineLikely)($event);
-
-            return;
-        }
-
-        if ($classification === 'unknown' && $this->onUnknown !== null) {
-            ($this->onUnknown)($event);
-        }
+        if ($this->onAmdResult) ($this->onAmdResult)($event);
+        if ($classification === 'human_likely' && $this->onHumanLikely) { ($this->onHumanLikely)($event); return; }
+        if ($classification === 'machine_likely' && $this->onMachineLikely) { ($this->onMachineLikely)($event); return; }
+        if ($classification === 'unknown' && $this->onUnknown) ($this->onUnknown)($event);
     }
 
     private function analyzeTone425(array $samples): array
     {
-        if ($samples === []) {
-            return [
-                'detected' => false,
-                'frequency_hz' => 0.0,
-                'level_dbfs' => -120.0,
-                'prominence_db' => 0.0,
-            ];
-        }
-
+        if ($samples === []) return ['detected' => false, 'frequency_hz' => 0.0, 'level_dbfs' => -120.0, 'prominence_db' => 0.0];
         $windowed = $this->applyHannWindow($samples);
-
         $bestFrequency = 425.0;
         $bestLevel = -120.0;
-
         for ($frequency = 395; $frequency <= 455; $frequency += 5) {
-            $level = $this->goertzelDbfs(
-                $windowed,
-                (float) $frequency
-            );
-
-            if ($level > $bestLevel) {
-                $bestLevel = $level;
-                $bestFrequency = (float) $frequency;
-            }
+            $level = $this->goertzelDbfs($windowed, (float) $frequency);
+            if ($level > $bestLevel) { $bestLevel = $level; $bestFrequency = (float) $frequency; }
         }
-
-        $refineStart = max(395, (int) $bestFrequency - 5);
-        $refineEnd = min(455, (int) $bestFrequency + 5);
-
-        for ($frequency = $refineStart; $frequency <= $refineEnd; $frequency++) {
-            $level = $this->goertzelDbfs(
-                $windowed,
-                (float) $frequency
-            );
-
-            if ($level > $bestLevel) {
-                $bestLevel = $level;
-                $bestFrequency = (float) $frequency;
-            }
+        for ($frequency = max(395, (int) $bestFrequency - 5); $frequency <= min(455, (int) $bestFrequency + 5); $frequency++) {
+            $level = $this->goertzelDbfs($windowed, (float) $frequency);
+            if ($level > $bestLevel) { $bestLevel = $level; $bestFrequency = (float) $frequency; }
         }
-
-        $backgroundFrequencies = [
-            250.0,
-            300.0,
-            350.0,
-            500.0,
-            600.0,
-            700.0,
-            850.0,
-            1000.0,
-            1200.0,
-        ];
-
-        $backgroundLevels = [];
-
-        foreach ($backgroundFrequencies as $frequency) {
-            $backgroundLevels[] = $this->goertzelDbfs(
-                $windowed,
-                $frequency
-            );
+        $levels = [];
+        foreach ([250.0, 300.0, 350.0, 500.0, 600.0, 700.0, 850.0, 1000.0, 1200.0] as $frequency) {
+            $levels[] = $this->goertzelDbfs($windowed, $frequency);
         }
-
-        $backgroundLevel = $this->median($backgroundLevels);
-        $prominenceDb = $bestLevel - $backgroundLevel;
-
-        $detected =
-            $bestFrequency >= 395.0 &&
-            $bestFrequency <= 455.0 &&
-            $bestLevel >= $this->tone425MinimumDbfs &&
-            $prominenceDb >= $this->tone425MinimumProminenceDb;
-
+        $prominence = $bestLevel - $this->median($levels);
         return [
-            'detected' => $detected,
+            'detected' => $bestLevel >= $this->tone425MinimumDbfs && $prominence >= $this->tone425MinimumProminenceDb,
             'frequency_hz' => $bestFrequency,
             'level_dbfs' => $bestLevel,
-            'prominence_db' => $prominenceDb,
+            'prominence_db' => $prominence,
         ];
     }
 
     private function decodePcm16LittleEndian(string $pcm): array
     {
-        if ($pcm === '' || (strlen($pcm) % 2) !== 0) {
-            return [];
-        }
-
+        if ($pcm === '' || strlen($pcm) % 2 !== 0) return [];
         $values = unpack('v*', $pcm);
-
-        if ($values === false) {
-            return [];
-        }
-
+        if ($values === false) return [];
         $samples = [];
-
-        foreach ($values as $value) {
-            if ($value >= 0x8000) {
-                $value -= 0x10000;
-            }
-
-            $samples[] = (float) $value;
-        }
-
+        foreach ($values as $value) $samples[] = (float) ($value >= 0x8000 ? $value - 0x10000 : $value);
         return $samples;
     }
 
     private function calculateRmsDbfs(array $samples): float
     {
-        if ($samples === []) {
-            return -120.0;
-        }
-
-        $sumSquares = 0.0;
-
-        foreach ($samples as $sample) {
-            $sumSquares += $sample * $sample;
-        }
-
-        $rms = sqrt($sumSquares / count($samples));
-
-        if ($rms <= 0.0) {
-            return -120.0;
-        }
-
-        return max(
-            -120.0,
-            20.0 * log10($rms / 32768.0)
-        );
+        if ($samples === []) return -120.0;
+        $sum = 0.0;
+        foreach ($samples as $sample) $sum += $sample * $sample;
+        $rms = sqrt($sum / count($samples));
+        return $rms > 0.0 ? max(-120.0, 20.0 * log10($rms / 32768.0)) : -120.0;
     }
 
     private function applyHannWindow(array $samples): array
     {
         $count = count($samples);
-
-        if ($count <= 1) {
-            return $samples;
-        }
-
+        if ($count <= 1) return $samples;
         $result = [];
-        $divisor = $count - 1;
-
         foreach ($samples as $index => $sample) {
-            $coefficient = 0.5 * (
-                1.0 - cos(
-                    (2.0 * M_PI * $index) / $divisor
-                )
-            );
-
-            $result[] = $sample * $coefficient;
+            $result[] = $sample * (0.5 * (1.0 - cos((2.0 * M_PI * $index) / ($count - 1))));
         }
-
         return $result;
     }
 
     private function goertzelDbfs(array $samples, float $frequency): float
     {
-        $sampleCount = count($samples);
-
-        if ($sampleCount === 0) {
-            return -120.0;
-        }
-
-        $omega = (2.0 * M_PI * $frequency) / $this->sampleRate;
-        $coefficient = 2.0 * cos($omega);
-
+        $count = count($samples);
+        if ($count === 0) return -120.0;
+        $coefficient = 2.0 * cos((2.0 * M_PI * $frequency) / $this->sampleRate);
         $previous = 0.0;
         $previousPrevious = 0.0;
-
         foreach ($samples as $sample) {
-            $current =
-                $sample +
-                ($coefficient * $previous) -
-                $previousPrevious;
-
+            $current = $sample + ($coefficient * $previous) - $previousPrevious;
             $previousPrevious = $previous;
             $previous = $current;
         }
-
-        $power =
-            ($previous * $previous) +
-            ($previousPrevious * $previousPrevious) -
-            ($coefficient * $previous * $previousPrevious);
-
-        if ($power <= 0.0) {
-            return -120.0;
-        }
-
-        $magnitude = sqrt($power);
-        $amplitude = (4.0 * $magnitude) / $sampleCount;
-
-        if ($amplitude <= 0.0) {
-            return -120.0;
-        }
-
-        return max(
-            -120.0,
-            min(
-                0.0,
-                20.0 * log10($amplitude / 32768.0)
-            )
-        );
+        $power = ($previous * $previous) + ($previousPrevious * $previousPrevious) - ($coefficient * $previous * $previousPrevious);
+        if ($power <= 0.0) return -120.0;
+        $amplitude = (4.0 * sqrt($power)) / $count;
+        return $amplitude > 0.0 ? max(-120.0, min(0.0, 20.0 * log10($amplitude / 32768.0))) : -120.0;
     }
 
     private function median(array $values): float
     {
-        if ($values === []) {
-            return -120.0;
-        }
-
+        if ($values === []) return -120.0;
         sort($values, SORT_NUMERIC);
-
         $count = count($values);
         $middle = intdiv($count, 2);
-
-        if (($count % 2) === 1) {
-            return (float) $values[$middle];
-        }
-
-        return (
-            $values[$middle - 1] +
-            $values[$middle]
-        ) / 2.0;
+        return $count % 2 === 1 ? (float) $values[$middle] : ($values[$middle - 1] + $values[$middle]) / 2.0;
     }
 }

--- a/plugins/Utils/audio/EarlyGreetingDetector.php
+++ b/plugins/Utils/audio/EarlyGreetingDetector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace libspech\audio;
+
 use Closure;
 use InvalidArgumentException;
 
@@ -24,6 +25,23 @@ final class EarlyGreetingDetector
     private int $voiceFramesMs = 0;
     private int $voiceGapMs = 0;
     private bool $greetingReported = false;
+    private bool $earlyGreetingDetected = false;
+
+    private int $postAnswerElapsedMs = 0;
+    private bool $postAnswerVoiceActive = false;
+    private int $postAnswerVoiceStartedAtMs = 0;
+    private int $postAnswerCurrentVoiceMs = 0;
+    private int $postAnswerCurrentGapMs = 0;
+    private int $postAnswerLastSpeechMs = 0;
+    private int $postAnswerSilenceAfterSpeechMs = 0;
+    private int $postAnswerSpeechSegments = 0;
+    private int $postAnswerTotalVoiceMs = 0;
+    private int $postAnswerLongestVoiceMs = 0;
+    private bool $voiceCrossedAnswer = false;
+    private int $earlyVoiceAtAnswerMs = 0;
+
+    private ?string $amdResult = null;
+    private ?string $amdReason = null;
 
     private float $noiseFloorDbfs = -65.0;
 
@@ -32,36 +50,66 @@ final class EarlyGreetingDetector
     private ?Closure $onGreetingDetected = null;
     private ?Closure $onAnalysis = null;
     private ?Closure $onAnswerBoundary = null;
+    private ?Closure $onHumanLikely = null;
+    private ?Closure $onMachineLikely = null;
+    private ?Closure $onUnknown = null;
+    private ?Closure $onAmdResult = null;
 
     public function __construct(
-        private readonly int   $sampleRate = 8000,
-        private readonly int   $frameDurationMs = 20,
-        private readonly int   $analysisWindowMs = 200,
-        private readonly int   $minimumGreetingVoiceMs = 800,
-        private readonly int   $maximumInternalGapMs = 120,
+        private readonly int $sampleRate = 8000,
+        private readonly int $frameDurationMs = 20,
+        private readonly int $analysisWindowMs = 200,
+        private readonly int $minimumGreetingVoiceMs = 800,
+        private readonly int $maximumInternalGapMs = 120,
         private readonly float $minimumVoiceDbfs = -42.0,
         private readonly float $noiseMarginDb = 10.0,
         private readonly float $tone425MinimumDbfs = -45.0,
         private readonly float $tone425MinimumProminenceDb = 14.0,
-    )
-    {
+        private readonly int $humanMinimumSpeechMs = 200,
+        private readonly int $humanMaximumSpeechMs = 1200,
+        private readonly int $humanSilenceAfterSpeechMs = 600,
+        private readonly int $machineGreetingVoiceMs = 2000,
+        private readonly int $postAnswerAnalysisTimeoutMs = 6000,
+    ) {
         if ($this->sampleRate <= 0) {
-            throw new InvalidArgumentException(
-                'sampleRate deve ser maior que zero.'
-            );
+            throw new InvalidArgumentException('sampleRate deve ser maior que zero.');
         }
 
         if ($this->frameDurationMs <= 0) {
+            throw new InvalidArgumentException('frameDurationMs deve ser maior que zero.');
+        }
+
+        if ($this->analysisWindowMs < $this->frameDurationMs) {
             throw new InvalidArgumentException(
-                'frameDurationMs deve ser maior que zero.'
+                'analysisWindowMs deve ser maior ou igual a frameDurationMs.'
             );
         }
 
-        $frameSamples = (int)round(
+        if ($this->humanMinimumSpeechMs < 0) {
+            throw new InvalidArgumentException('humanMinimumSpeechMs não pode ser negativo.');
+        }
+
+        if ($this->humanMaximumSpeechMs < $this->humanMinimumSpeechMs) {
+            throw new InvalidArgumentException(
+                'humanMaximumSpeechMs deve ser maior ou igual a humanMinimumSpeechMs.'
+            );
+        }
+
+        if ($this->machineGreetingVoiceMs <= 0) {
+            throw new InvalidArgumentException('machineGreetingVoiceMs deve ser maior que zero.');
+        }
+
+        if ($this->postAnswerAnalysisTimeoutMs <= 0) {
+            throw new InvalidArgumentException(
+                'postAnswerAnalysisTimeoutMs deve ser maior que zero.'
+            );
+        }
+
+        $frameSamples = (int) round(
             $this->sampleRate * ($this->frameDurationMs / 1000)
         );
 
-        $analysisSamples = (int)round(
+        $analysisSamples = (int) round(
             $this->sampleRate * ($this->analysisWindowMs / 1000)
         );
 
@@ -105,6 +153,34 @@ final class EarlyGreetingDetector
         return $this;
     }
 
+    public function onHumanLikely(callable $callback): self
+    {
+        $this->onHumanLikely = Closure::fromCallable($callback);
+
+        return $this;
+    }
+
+    public function onMachineLikely(callable $callback): self
+    {
+        $this->onMachineLikely = Closure::fromCallable($callback);
+
+        return $this;
+    }
+
+    public function onUnknown(callable $callback): self
+    {
+        $this->onUnknown = Closure::fromCallable($callback);
+
+        return $this;
+    }
+
+    public function onAmdResult(callable $callback): self
+    {
+        $this->onAmdResult = Closure::fromCallable($callback);
+
+        return $this;
+    }
+
     public function push(string $pcmData): void
     {
         if ($pcmData === '') {
@@ -114,16 +190,8 @@ final class EarlyGreetingDetector
         $this->frameBuffer .= $pcmData;
 
         while (strlen($this->frameBuffer) >= $this->frameBytes) {
-            $frame = substr(
-                $this->frameBuffer,
-                0,
-                $this->frameBytes
-            );
-
-            $this->frameBuffer = substr(
-                $this->frameBuffer,
-                $this->frameBytes
-            );
+            $frame = substr($this->frameBuffer, 0, $this->frameBytes);
+            $this->frameBuffer = substr($this->frameBuffer, $this->frameBytes);
 
             $this->processFrame($frame);
         }
@@ -137,6 +205,19 @@ final class EarlyGreetingDetector
 
         $this->answered = true;
         $this->answeredAtMs = $this->elapsedMs;
+        $this->postAnswerElapsedMs = 0;
+        $this->voiceCrossedAnswer = $this->voiceActive;
+        $this->earlyVoiceAtAnswerMs = $this->voiceActive
+            ? $this->voiceFramesMs
+            : 0;
+
+        if ($this->voiceCrossedAnswer) {
+            $this->postAnswerVoiceActive = true;
+            $this->postAnswerVoiceStartedAtMs = $this->elapsedMs;
+            $this->postAnswerSpeechSegments = 1;
+            $this->postAnswerCurrentVoiceMs = 0;
+            $this->postAnswerCurrentGapMs = 0;
+        }
 
         $event = [
             'audio_ms' => $this->elapsedMs,
@@ -145,36 +226,53 @@ final class EarlyGreetingDetector
                 ? $this->voiceStartedAtMs
                 : null,
             'early_voice_ms' => $this->voiceFramesMs,
-            'greeting_detected' => $this->greetingReported,
+            'greeting_detected' => $this->earlyGreetingDetected,
+            'voice_crossed_answer' => $this->voiceCrossedAnswer,
         ];
 
         if ($this->onAnswerBoundary !== null) {
             ($this->onAnswerBoundary)($event);
         }
-
-        /*
-         * A primeira experiência termina aqui.
-         *
-         * Não apagamos os dados, porque eles ainda podem ser
-         * consultados depois do 200 OK.
-         */
     }
 
     public function finish(string $reason = 'finished'): void
     {
-        if ($this->voiceActive) {
-            $this->finishVoiceSegment($reason);
+        if (!$this->answered && $this->voiceActive) {
+            $this->finishEarlyVoiceSegment($reason);
+        }
+
+        if ($this->answered && $this->postAnswerVoiceActive) {
+            $this->finishPostAnswerVoiceSegment($reason);
+        }
+
+        if ($this->answered && $this->amdResult === null) {
+            $this->emitAmdResult('unknown', $reason);
         }
     }
 
     public function isGreetingDetected(): bool
     {
-        return $this->greetingReported;
+        return $this->earlyGreetingDetected;
+    }
+
+    public function isAnswered(): bool
+    {
+        return $this->answered;
     }
 
     public function getAnsweredAtMs(): ?int
     {
         return $this->answeredAtMs;
+    }
+
+    public function getAmdResult(): ?string
+    {
+        return $this->amdResult;
+    }
+
+    public function getAmdReason(): ?string
+    {
+        return $this->amdReason;
     }
 
     private function processFrame(string $frame): void
@@ -206,9 +304,6 @@ final class EarlyGreetingDetector
             'prominence_db' => 0.0,
         ];
 
-        /*
-         * Só analisamos o tom quando tivermos 200 ms acumulados.
-         */
         if (strlen($this->analysisBuffer) >= $this->analysisWindowBytes) {
             $analysisSamples = $this->decodePcm16LittleEndian(
                 $this->analysisBuffer
@@ -222,18 +317,11 @@ final class EarlyGreetingDetector
             $this->noiseFloorDbfs + $this->noiseMarginDb
         );
 
-        /*
-         * Ringback de 425 Hz possui energia alta e seria confundido
-         * com voz por um VAD baseado apenas em volume.
-         */
+        // O tom de ringback não deve ser contado como voz.
         $isVoice =
             $rmsDbfs >= $voiceThresholdDbfs &&
             !$tone425['detected'];
 
-        /*
-         * Atualiza o piso de ruído somente quando o frame não parece
-         * ser voz e não é o tom de 425 Hz.
-         */
         if (
             !$isVoice &&
             !$tone425['detected'] &&
@@ -254,33 +342,35 @@ final class EarlyGreetingDetector
             'voice_threshold_dbfs' => $voiceThresholdDbfs,
             'voice' => $isVoice,
             'tone_425' => $tone425,
+            'amd_result' => $this->amdResult,
         ];
 
         if ($this->onAnalysis !== null) {
             ($this->onAnalysis)($analysis);
         }
 
-        /*
-         * Para esta experiência, somente frames anteriores ao
-         * 200 OK participam da detecção de saudação antecipada.
-         */
-        if ($this->answered) {
+        if (!$this->answered) {
+            $this->updateEarlyVoiceState(
+                isVoice: $isVoice,
+                frameStartMs: $frameStartMs,
+                analysis: $analysis
+            );
+
             return;
         }
 
-        $this->updateVoiceState(
+        $this->updatePostAnswerState(
             isVoice: $isVoice,
             frameStartMs: $frameStartMs,
             analysis: $analysis
         );
     }
 
-    private function updateVoiceState(
-        bool  $isVoice,
-        int   $frameStartMs,
+    private function updateEarlyVoiceState(
+        bool $isVoice,
+        int $frameStartMs,
         array $analysis
-    ): void
-    {
+    ): void {
         if ($isVoice) {
             if (!$this->voiceActive) {
                 $this->voiceActive = true;
@@ -306,6 +396,7 @@ final class EarlyGreetingDetector
                 $this->voiceFramesMs >= $this->minimumGreetingVoiceMs
             ) {
                 $this->greetingReported = true;
+                $this->earlyGreetingDetected = true;
 
                 if ($this->onGreetingDetected !== null) {
                     ($this->onGreetingDetected)([
@@ -327,17 +418,14 @@ final class EarlyGreetingDetector
 
         $this->voiceGapMs += $this->frameDurationMs;
 
-        /*
-         * Pequenas pausas dentro da fala não encerram a saudação.
-         */
         if ($this->voiceGapMs <= $this->maximumInternalGapMs) {
             return;
         }
 
-        $this->finishVoiceSegment('silence');
+        $this->finishEarlyVoiceSegment('silence');
     }
 
-    private function finishVoiceSegment(string $reason): void
+    private function finishEarlyVoiceSegment(string $reason): void
     {
         if (!$this->voiceActive) {
             return;
@@ -350,9 +438,7 @@ final class EarlyGreetingDetector
             'gap_ms' => $this->voiceGapMs,
             'greeting_detected' => $this->greetingReported,
             'reason' => $reason,
-            'phase' => $this->answered
-                ? 'answered'
-                : 'early_media',
+            'phase' => 'early_media',
         ];
 
         if ($this->onVoiceEnd !== null) {
@@ -364,6 +450,177 @@ final class EarlyGreetingDetector
         $this->voiceFramesMs = 0;
         $this->voiceGapMs = 0;
         $this->greetingReported = false;
+    }
+
+    private function updatePostAnswerState(
+        bool $isVoice,
+        int $frameStartMs,
+        array $analysis
+    ): void {
+        if ($this->answeredAtMs === null) {
+            return;
+        }
+
+        $this->postAnswerElapsedMs = max(
+            0,
+            $this->elapsedMs - $this->answeredAtMs
+        );
+
+        if ($this->amdResult !== null) {
+            return;
+        }
+
+        if ($isVoice) {
+            if (!$this->postAnswerVoiceActive) {
+                $this->postAnswerVoiceActive = true;
+                $this->postAnswerVoiceStartedAtMs = $frameStartMs;
+                $this->postAnswerCurrentVoiceMs = 0;
+                $this->postAnswerCurrentGapMs = 0;
+                $this->postAnswerSilenceAfterSpeechMs = 0;
+                $this->postAnswerSpeechSegments++;
+
+                if ($this->onVoiceStart !== null) {
+                    ($this->onVoiceStart)([
+                        'audio_ms' => $frameStartMs,
+                        'post_answer_ms' => $this->postAnswerElapsedMs,
+                        'rms_dbfs' => $analysis['rms_dbfs'],
+                        'phase' => 'answered',
+                    ]);
+                }
+            }
+
+            $this->postAnswerCurrentVoiceMs += $this->frameDurationMs;
+            $this->postAnswerTotalVoiceMs += $this->frameDurationMs;
+            $this->postAnswerCurrentGapMs = 0;
+            $this->postAnswerSilenceAfterSpeechMs = 0;
+            $this->postAnswerLongestVoiceMs = max(
+                $this->postAnswerLongestVoiceMs,
+                $this->postAnswerCurrentVoiceMs
+            );
+
+            $continuousVoiceMs =
+                $this->postAnswerCurrentVoiceMs +
+                ($this->voiceCrossedAnswer ? $this->earlyVoiceAtAnswerMs : 0);
+
+            if ($continuousVoiceMs >= $this->machineGreetingVoiceMs) {
+                $this->emitAmdResult('machine_likely', 'long_greeting');
+
+                return;
+            }
+        } elseif ($this->postAnswerVoiceActive) {
+            $this->postAnswerCurrentGapMs += $this->frameDurationMs;
+
+            if ($this->postAnswerCurrentGapMs > $this->maximumInternalGapMs) {
+                $this->finishPostAnswerVoiceSegment('silence');
+            }
+        } elseif ($this->postAnswerSpeechSegments > 0) {
+            $this->postAnswerSilenceAfterSpeechMs += $this->frameDurationMs;
+
+            if (
+                !$this->voiceCrossedAnswer &&
+                $this->postAnswerSpeechSegments === 1 &&
+                $this->postAnswerLastSpeechMs >= $this->humanMinimumSpeechMs &&
+                $this->postAnswerLastSpeechMs <= $this->humanMaximumSpeechMs &&
+                $this->postAnswerSilenceAfterSpeechMs >= $this->humanSilenceAfterSpeechMs
+            ) {
+                $this->emitAmdResult(
+                    'human_likely',
+                    'short_greeting_followed_by_silence'
+                );
+
+                return;
+            }
+        }
+
+        if (
+            $this->amdResult === null &&
+            $this->postAnswerElapsedMs >= $this->postAnswerAnalysisTimeoutMs
+        ) {
+            $this->emitAmdResult('unknown', 'analysis_timeout');
+        }
+    }
+
+    private function finishPostAnswerVoiceSegment(string $reason): void
+    {
+        if (!$this->postAnswerVoiceActive) {
+            return;
+        }
+
+        $this->postAnswerLastSpeechMs = $this->postAnswerCurrentVoiceMs;
+        $this->postAnswerLongestVoiceMs = max(
+            $this->postAnswerLongestVoiceMs,
+            $this->postAnswerLastSpeechMs
+        );
+
+        $event = [
+            'audio_ms' => $this->elapsedMs,
+            'post_answer_ms' => $this->postAnswerElapsedMs,
+            'started_at_ms' => $this->postAnswerVoiceStartedAtMs,
+            'voiced_ms' => $this->postAnswerLastSpeechMs,
+            'gap_ms' => $this->postAnswerCurrentGapMs,
+            'speech_segments' => $this->postAnswerSpeechSegments,
+            'greeting_detected' => false,
+            'voice_crossed_answer' => $this->voiceCrossedAnswer,
+            'reason' => $reason,
+            'phase' => 'answered',
+        ];
+
+        if ($this->onVoiceEnd !== null) {
+            ($this->onVoiceEnd)($event);
+        }
+
+        $this->postAnswerVoiceActive = false;
+        $this->postAnswerVoiceStartedAtMs = 0;
+        $this->postAnswerCurrentVoiceMs = 0;
+        $this->postAnswerCurrentGapMs = 0;
+        $this->postAnswerSilenceAfterSpeechMs = 0;
+    }
+
+    private function emitAmdResult(string $classification, string $reason): void
+    {
+        if ($this->amdResult !== null) {
+            return;
+        }
+
+        $this->amdResult = $classification;
+        $this->amdReason = $reason;
+
+        $event = [
+            'audio_ms' => $this->elapsedMs,
+            'answered_at_ms' => $this->answeredAtMs,
+            'post_answer_ms' => $this->postAnswerElapsedMs,
+            'classification' => $classification,
+            'reason' => $reason,
+            'voice_crossed_answer' => $this->voiceCrossedAnswer,
+            'early_greeting_detected' => $this->earlyGreetingDetected,
+            'early_voice_at_answer_ms' => $this->earlyVoiceAtAnswerMs,
+            'speech_segments' => $this->postAnswerSpeechSegments,
+            'current_speech_ms' => $this->postAnswerCurrentVoiceMs,
+            'last_speech_ms' => $this->postAnswerLastSpeechMs,
+            'total_voice_ms' => $this->postAnswerTotalVoiceMs,
+            'longest_voice_ms' => $this->postAnswerLongestVoiceMs,
+            'silence_after_speech_ms' => $this->postAnswerSilenceAfterSpeechMs,
+        ];
+
+        if ($this->onAmdResult !== null) {
+            ($this->onAmdResult)($event);
+        }
+
+        if ($classification === 'human_likely' && $this->onHumanLikely !== null) {
+            ($this->onHumanLikely)($event);
+
+            return;
+        }
+
+        if ($classification === 'machine_likely' && $this->onMachineLikely !== null) {
+            ($this->onMachineLikely)($event);
+
+            return;
+        }
+
+        if ($classification === 'unknown' && $this->onUnknown !== null) {
+            ($this->onUnknown)($event);
+        }
     }
 
     private function analyzeTone425(array $samples): array
@@ -379,45 +636,36 @@ final class EarlyGreetingDetector
 
         $windowed = $this->applyHannWindow($samples);
 
-        /*
-         * Primeiro faz uma busca grossa.
-         */
         $bestFrequency = 425.0;
         $bestLevel = -120.0;
 
         for ($frequency = 395; $frequency <= 455; $frequency += 5) {
             $level = $this->goertzelDbfs(
                 $windowed,
-                (float)$frequency
+                (float) $frequency
             );
 
             if ($level > $bestLevel) {
                 $bestLevel = $level;
-                $bestFrequency = (float)$frequency;
+                $bestFrequency = (float) $frequency;
             }
         }
 
-        /*
-         * Depois refina em passos de 1 Hz.
-         */
-        $refineStart = max(395, (int)$bestFrequency - 5);
-        $refineEnd = min(455, (int)$bestFrequency + 5);
+        $refineStart = max(395, (int) $bestFrequency - 5);
+        $refineEnd = min(455, (int) $bestFrequency + 5);
 
         for ($frequency = $refineStart; $frequency <= $refineEnd; $frequency++) {
             $level = $this->goertzelDbfs(
                 $windowed,
-                (float)$frequency
+                (float) $frequency
             );
 
             if ($level > $bestLevel) {
                 $bestLevel = $level;
-                $bestFrequency = (float)$frequency;
+                $bestFrequency = (float) $frequency;
             }
         }
 
-        /*
-         * Frequências de referência fora da faixa do ringback.
-         */
         $backgroundFrequencies = [
             250.0,
             300.0,
@@ -475,7 +723,7 @@ final class EarlyGreetingDetector
                 $value -= 0x10000;
             }
 
-            $samples[] = (float)$value;
+            $samples[] = (float) $value;
         }
 
         return $samples;
@@ -518,10 +766,10 @@ final class EarlyGreetingDetector
 
         foreach ($samples as $index => $sample) {
             $coefficient = 0.5 * (
-                    1.0 - cos(
-                        (2.0 * M_PI * $index) / $divisor
-                    )
-                );
+                1.0 - cos(
+                    (2.0 * M_PI * $index) / $divisor
+                )
+            );
 
             $result[] = $sample * $coefficient;
         }
@@ -529,10 +777,7 @@ final class EarlyGreetingDetector
         return $result;
     }
 
-    private function goertzelDbfs(
-        array $samples,
-        float $frequency
-    ): float
+    private function goertzelDbfs(array $samples, float $frequency): float
     {
         $sampleCount = count($samples);
 
@@ -540,10 +785,7 @@ final class EarlyGreetingDetector
             return -120.0;
         }
 
-        $omega = (
-                2.0 * M_PI * $frequency
-            ) / $this->sampleRate;
-
+        $omega = (2.0 * M_PI * $frequency) / $this->sampleRate;
         $coefficient = 2.0 * cos($omega);
 
         $previous = 0.0;
@@ -569,13 +811,7 @@ final class EarlyGreetingDetector
         }
 
         $magnitude = sqrt($power);
-
-        /*
-         * Correção aproximada para janela Hann.
-         */
-        $amplitude = (
-                4.0 * $magnitude
-            ) / $sampleCount;
+        $amplitude = (4.0 * $magnitude) / $sampleCount;
 
         if ($amplitude <= 0.0) {
             return -120.0;
@@ -602,12 +838,12 @@ final class EarlyGreetingDetector
         $middle = intdiv($count, 2);
 
         if (($count % 2) === 1) {
-            return (float)$values[$middle];
+            return (float) $values[$middle];
         }
 
         return (
-                $values[$middle - 1] +
-                $values[$middle]
-            ) / 2.0;
+            $values[$middle - 1] +
+            $values[$middle]
+        ) / 2.0;
     }
 }


### PR DESCRIPTION
## Resumo

Evolui o `EarlyGreetingDetector` para continuar analisando os frames PCM depois do `200 OK`, mantendo a detecção de saudação em early media já existente.

## Implementação

- continua a análise no mesmo `onReceivePcm()` após `markAnswered()`;
- preserva voz que começou antes do `200 OK` e atravessou a fronteira de atendimento;
- classifica `human_likely` quando há fala curta seguida de silêncio;
- classifica `machine_likely` quando há saudação contínua longa;
- retorna `unknown` ao atingir o tempo máximo sem decisão;
- impede emissão duplicada do resultado AMD;
- adiciona callbacks:
  - `onHumanLikely()`;
  - `onMachineLikely()`;
  - `onUnknown()`;
  - `onAmdResult()`;
- adiciona `getAmdResult()`, `getAmdReason()` e `isAnswered()`;
- mantém o histórico de saudação detectada antes do `200 OK`;
- continua excluindo o tom de aproximadamente 425 Hz do VAD para não classificar ringback como voz.

## Parâmetros padrão

- humano: fala entre 200 e 1200 ms, seguida por 600 ms de silêncio;
- máquina: fala contínua de 2000 ms;
- timeout de análise pós-atendimento: 6000 ms;
- tolerância de pausas internas: mantém o valor atual de 120 ms.

Todos os limites continuam configuráveis no construtor.

## Validação

- `php -l` sem erros;
- teste sintético com PCM16 8 kHz validando:
  - fala curta + silêncio => `human_likely`;
  - fala longa => `machine_likely`.

## Próxima etapa

Adicionar detecção específica do beep final da caixa postal para promover `machine_likely` a uma confirmação mais forte.